### PR TITLE
Add Fission auth

### DIFF
--- a/common/useFissionAuth.ts
+++ b/common/useFissionAuth.ts
@@ -159,7 +159,7 @@ export function useFissionAuth({ host, protocol }) {
    * 
    * See the WNFS guide for the non-blocking implemenation of publish: 
    * https://guide.fission.codes/developers/webnative/file-system-wnfs
-   * 
+   *
    * NOTE(bgins)
    */
 
@@ -189,36 +189,38 @@ export function useFissionAuth({ host, protocol }) {
     if (fs) {
       console.log('Estuary has wallet stored as', savedAddress)
 
-      // Get or create a wallet
+      // NOTE(bgins): Get or create a wallet
       wallet = await WebnativeFilecoin.getWallet(fs, Webnative, { keyname: 'estuary-fil-cosigner' });
 
-      // After we get the wallet, we can check its address
+      // NOTE(bgins): After we get the wallet, we can check its address
       const address = wallet.getAddress();
       console.log('cosigner says wallet is', address)
 
-      // And we can check its balance
+      // NOTE(bgins): And we can check its balance
       const balance = await wallet.getBalance();
       console.log('wallet balance is', balance)
 
-      // We can also check the provider address
+      // NOTE(bgins): We can also check the provider address
       const providerAddress = await wallet.getProviderAddress();
       console.log('provider address', providerAddress)
 
-      // And the provider balance
+      // NOTE(bgins): And the provider balance
       const providerBalance = await wallet.getProviderBalance();
       console.log('balance held by provider', providerBalance)
 
       // Caution: this sends FIL and for moment is called when the settings page
       // is loaded. This includes reload on save when running on local development.
       // Be careful or the monies will be flying 💸
+      // NOTE(bgins)
       //
       // await testTransactions(wallet, balance);
 
       // TODO: check what the default value for the wallet is before the user sets one
       // We assume null here, but it might be '<empty>'
+      // NOTE(bgins)
       if (savedAddress === null || address !== savedAddress) {
 
-        // Store the wallet with the Estuary backend
+        // NOTE(bgins): Store the wallet with the Estuary backend
         const response = await R.put('/user/address', { address });
 
         return { address, isNew: true }
@@ -239,6 +241,8 @@ export function useFissionAuth({ host, protocol }) {
    *      and redirects to the auth lobby if we don't have them. A second check is
    *      performed on return from the auth lobby (we can the function again)
    *   2. Sends FIL to the provider and returns us a receipt
+   *
+   * NOTE(bgins)
    */
 
   const testTransactions = async (wallet: Wallet, balance: number) => {
@@ -249,11 +253,11 @@ export function useFissionAuth({ host, protocol }) {
       .then(async () => {
 
         if (balance > 0.001) {
-          // Send a small, hardcoded amount to the provider
+          // NOTE(bgins): Send a small, hardcoded amount to the provider
           const receipt = await wallet.fundProvider(0.001);
           console.log('receipt from transaction', receipt)
 
-          // We could also send funds to an arbtitrary wallet
+          // NOTE(bgins): We could also send funds to an arbtitrary wallet
           // const anotherReceipt = await wallet.send('<some-wallet-address>', 0.001);
           // console.log('receipt', anotherReceipt)
         } else {

--- a/common/useFissionAuth.ts
+++ b/common/useFissionAuth.ts
@@ -10,7 +10,7 @@ import Cookies from 'js-cookie';
 
 webnative.setup.debug({ enabled: true })
 
-export function useFissionAuth({ host,  protocol }) {
+export function useFissionAuth({ host, protocol }) {
   const [state, setState] = useState<webnative.State>(null)
   let fs;
   let authScenario: webnative.Scenario | null = null;
@@ -29,12 +29,12 @@ export function useFissionAuth({ host,  protocol }) {
           // at bgins/estuary-www.
           app: {
             name: 'estuary-www',
-            creator: 'bgins',
+            creator: 'arg',
           },
           fs: {
             // The cosigner key is stored in the private filesystem
             // at the path Keychain/fil-cosigner.
-            private: [webnativeFilecoin.DEFAULT_KEY_PERMISSION]
+            private: [webnative.path.file('Keychain', 'estuary-fil-cosigner')]
           }
         },
       })

--- a/common/useFissionAuth.ts
+++ b/common/useFissionAuth.ts
@@ -10,7 +10,7 @@ import Cookies from 'js-cookie';
 
 webnative.setup.debug({ enabled: true })
 
-export function useFissionAuth() {
+export function useFissionAuth({ host,  protocol }) {
   const [state, setState] = useState<webnative.State>(null)
   let fs;
   let authScenario: webnative.Scenario | null = null;
@@ -71,7 +71,7 @@ export function useFissionAuth() {
 
   const authorise = (redirectBackTo: string) => {
     if (state) {
-      webnative.redirectToLobby(state.permissions, `http://localhost:4444/${redirectBackTo}`)
+      webnative.redirectToLobby(state.permissions, `${protocol}://${host}/${redirectBackTo}`)
     }
   }
 
@@ -154,9 +154,7 @@ export function useFissionAuth() {
    */
 
   const publish = async (path) => {
-    console.log('fs', fs)
     if (fs) {
-      console.log('publishing')
       const cid = await fs.root.put();
       const ucan = await webnative.ucan.dictionary.lookupFilesystemUcan(path);
       await webnative.dataRoot.update(cid, ucan);

--- a/common/useFissionAuth.ts
+++ b/common/useFissionAuth.ts
@@ -1,0 +1,171 @@
+import { useEffect, useState } from 'react'
+
+import * as webnative from 'webnative'
+import * as webnativeFilecoin from 'webnative-filecoin';
+
+import * as C from '@common/constants';
+import * as R from '@common/requests';
+
+import Cookies from 'js-cookie';
+
+webnative.setup.debug({ enabled: true })
+
+export function useFissionAuth() {
+  const [state, setState] = useState<webnative.State>(null)
+  let fs;
+  let authScenario: webnative.Scenario | null = null;
+  let username: string = null;
+
+
+  /** Webnative Initialization
+   * Load webnative and configure permissions.
+   */
+
+  useEffect(() => {
+    async function getState() {
+      const result = await webnative.initialise({
+        permissions: {
+          // The Estuary token is stored in app storage
+          // at bgins/estuary-www.
+          app: {
+            name: 'estuary-www',
+            creator: 'bgins',
+          },
+          fs: {
+            // The cosigner key is stored in the private filesystem
+            // at the path Keychain/fil-cosigner.
+            private: [webnativeFilecoin.DEFAULT_KEY_PERMISSION]
+          }
+        },
+      })
+      setState(result)
+    }
+
+    getState()
+  }, [])
+
+
+  /** User and filesystem initialization
+   * If the user is authenticated with Fission, set their authScenario,
+   * filesytem, and username.
+   */
+
+  switch (state?.scenario) {
+    case webnative.Scenario.AuthSucceeded:
+    case webnative.Scenario.Continuation:
+      authScenario = state.scenario;
+      fs = state.fs;
+      username = state.username;
+      break;
+
+    default:
+      break;
+  }
+
+
+  /** Authorize
+   * Redirect the user to the Fission auth lobby where permission to use
+   * their filesystem will be requested. If they are new to Fission, they will
+   * first be asked to create an account.
+   */
+
+  const authorise = (redirectBackTo: string) => {
+    if (state) {
+      webnative.redirectToLobby(state.permissions, `http://localhost:4444/${redirectBackTo}`)
+    }
+  }
+
+
+  /** Sign in
+   * If the user is signed in with Fission, but not signed into Estuary, retrieve their
+   * Estuary token from WNFS. The token is stored encrypted at rest in WNFS.
+   * The stored token will be invalidated the next time that the user signs out, so we
+   * request a new token and store it in WNFS for the next sign in.
+   */
+
+  const signIn = async () => {
+    if (fs) {
+      // Auth with stored token
+      const token = await readToken()
+
+      if (token) {
+        // Set the token
+        Cookies.set(C.auth, token);
+
+        // Request a new token for the next time the user signs in
+        const j = await R.post(`/user/api-keys`, {});
+        if (j.error) {
+          return j;
+        }
+
+        if (!j.token) {
+          return {
+            error: 'Our server failed to sign you in. Please contact us.',
+          };
+        }
+
+        // Store the new token in WNFS
+        const tokenPath = fs.appPath(webnative.path.file(C.auth));
+        await fs.write(tokenPath, j.token);
+        await publish(tokenPath);
+
+        window.location.href = '/home';
+        return;
+      } else {
+        return {
+          error: 'We could not find your credentials stored with Fission. Please contact us.',
+        };
+      }
+    } else {
+      return {
+        error: 'We could not load your webnative file system. Please contact us.',
+      };
+    }
+  }
+
+
+  /** Read token
+   * Read the token from WNFS if it exists. Otherwise, return null to indicate
+   * that we don't have one.
+  */
+
+  const readToken = async () => {
+    if (fs) {
+      const tokenPath = fs.appPath(webnative.path.file(C.auth));
+
+      if (await fs.exists(tokenPath)) {
+        const token = await fs.read(tokenPath)
+        return token;
+      } else {
+        return null;
+      }
+    }
+  }
+
+
+  /** Publish
+   * Publish local changes to the user's filesystem on IPFS.
+   * This is a blocking implementation that should not be typically used, but we 
+   * use here to make sure we store tokens before changing window.location.href.
+   * 
+   * See the WNFS guide for the non-blocking implemenation of publish: 
+   * https://guide.fission.codes/developers/webnative/file-system-wnfs
+   * 
+   */
+
+  const publish = async (path) => {
+    console.log('fs', fs)
+    if (fs) {
+      console.log('publishing')
+      const cid = await fs.root.put();
+      const ucan = await webnative.ucan.dictionary.lookupFilesystemUcan(path);
+      await webnative.dataRoot.update(cid, ucan);
+    } else {
+      return {
+        error: 'We could not load your webnative file system. Please contact us.',
+      };
+    }
+  }
+
+  return { authorise, authScenario, fs, publish, readToken, signIn, username }
+}

--- a/common/useFissionAuth.ts
+++ b/common/useFissionAuth.ts
@@ -112,9 +112,8 @@ export function useFissionAuth({ host, protocol }) {
         window.location.href = '/home';
         return;
       } else {
-        return {
-          error: 'We could not find your credentials stored with Fission. Please contact us.',
-        };
+        window.location.href = '/account-setup';
+        return;
       }
     } else {
       return {

--- a/global.scss
+++ b/global.scss
@@ -133,6 +133,7 @@ body {
   --main-button-background: var(--main-primary);
   --main-button-text: #ffffff;
   --main-button-background-secondary: rgba(0, 0, 0, 1);
+  --main-button-background-fission: #6446fa;
   --main-button-text-secondary: #ffffff;
 
   --status-0: #387bf9;

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "sass": "1.34.1",
-    "webnative": "^0.25.2",
-    "webnative-filecoin": "^0.6.10"
+    "webnative": "0.24.2-alpha-2",
+    "webnative-filecoin": "0.6.10"
   },
   "devDependencies": {
     "@types/react": "^17.0.8",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^17.0.2",
     "sass": "1.34.1",
     "webnative": "^0.25.2",
-    "webnative-filecoin": "^0.6.8"
+    "webnative-filecoin": "^0.6.10"
   },
   "devDependencies": {
     "@types/react": "^17.0.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "next": "^10.2.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "sass": "1.34.1"
+    "sass": "1.34.1",
+    "webnative": "^0.25.2",
+    "webnative-filecoin": "^0.6.8"
   },
   "devDependencies": {
     "@types/react": "^17.0.8",

--- a/pages/account-setup.tsx
+++ b/pages/account-setup.tsx
@@ -4,9 +4,8 @@ import * as React from 'react';
 import * as U from '@common/utilities';
 import * as C from '@common/constants';
 import * as Crypto from '@common/crypto';
-import * as R from '@common/requests';
 
-import * as webnative from 'webnative';
+import * as Webnative from 'webnative';
 import { useFissionAuth } from '@common/useFissionAuth';
 
 import Cookies from 'js-cookie';
@@ -91,7 +90,8 @@ async function handleRegister(state: any) {
   }
 
   /** Request an API token to store for the next sign in
-   *  The token is stored encrypted at rest in WNFS.
+   * The token is stored encrypted at rest in WNFS.
+   * NOTE(bgins)
    */
 
   let response = await fetch(`${C.api.host}/user/api-keys`, {
@@ -119,7 +119,7 @@ async function handleRegister(state: any) {
     };
   }
 
-  const tokenPath = state.fs.appPath(webnative.path.file(C.auth));
+  const tokenPath = state.fs.appPath(Webnative.path.file(C.auth));
   await state.fs.write(tokenPath, json.token);
   const result = await state.publish(tokenPath);
 
@@ -127,7 +127,7 @@ async function handleRegister(state: any) {
     return result;
   }
 
-  // Set the first token granted and redirect to home
+  // NOTE(bgins): Set the first token granted and redirect to home
   Cookies.set(C.auth, j.token);
   window.location.href = '/home';
   return;
@@ -163,6 +163,7 @@ function AccountSetupPage(props: any) {
   /** Check for token
    * The user may already have an account. If we have a token stored for
    * them, redirect them to the Authed with Fission interstitial page
+   * NOTE(bgins)
    */
 
   React.useEffect(() => {

--- a/pages/account-setup.tsx
+++ b/pages/account-setup.tsx
@@ -19,6 +19,8 @@ import { H1, H2, H3, H4, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
+  const host = context.req.headers.host;
+  const protocol = host.split(':')[0] === 'localhost' ? 'http' : 'https';
 
   if (viewer) {
     return {
@@ -30,7 +32,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer },
+    props: { viewer, host, protocol },
   };
 }
 
@@ -139,7 +141,7 @@ function AccountSetupPage(props: any) {
     loading: false,
     fs: null,
   });
-  const { fs, publish, readToken, username } = useFissionAuth();
+  const { fs, publish, readToken, username } = useFissionAuth({ host: props.host, protocol: props.protocol });
 
   React.useEffect(() => {
     const params = new URLSearchParams(window.location.search);

--- a/pages/account-setup.tsx
+++ b/pages/account-setup.tsx
@@ -257,6 +257,17 @@ function AccountSetupPage(props: any) {
           >
             Set up account
           </Button>
+          <Button
+            style={{
+              width: '100%',
+              marginTop: 12,
+              background: 'var(--main-button-background-secondary)',
+              color: 'var(--main-button-text-secondary)',
+            }}
+            href="/sign-in"
+          >
+            Sign in instead
+          </Button>
         </div>
         <aside className={styles.formAside} style={{ marginTop: 8, display: 'block' }}>
           By creating an account or by using Estuary you unconditionally agree to our{' '}

--- a/pages/account-setup.tsx
+++ b/pages/account-setup.tsx
@@ -4,13 +4,13 @@ import * as React from 'react';
 import * as U from '@common/utilities';
 import * as C from '@common/constants';
 import * as Crypto from '@common/crypto';
+import * as R from '@common/requests';
 
 import * as webnative from 'webnative';
 import { useFissionAuth } from '@common/useFissionAuth';
 
 import Cookies from 'js-cookie';
 import Page from '@components/Page';
-import Navigation from '@components/Navigation';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 import Input from '@components/Input';
 import Button from '@components/Button';
@@ -88,28 +88,58 @@ async function handleRegister(state: any) {
     };
   }
 
+  /** Request an API token to store for the next sign in
+   *  The token is stored encrypted at rest in WNFS.
+   */
+
+  let response = await fetch(`${C.api.host}/user/api-keys`, {
+    method: 'POST',
+    body: '{}',
+    headers: {
+      Authorization: `Bearer ${j.token}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (response.status === 403) {
+    return { error: 'You are not authorized.' };
+  }
+
+  const json = await response.json();
+  if (json.error) {
+    return json;
+  }
+
+  if (!json.token) {
+    return {
+      error: 'Our server failed to issue you credentials. Please contact us.',
+    };
+  }
+
+  const tokenPath = state.fs.appPath(webnative.path.file(C.auth));
+  await state.fs.write(tokenPath, json.token);
+  const result = await state.publish(tokenPath);
+
+  if (result?.error) {
+    return result;
+  }
+
+  // Set the first token granted and redirect to home
   Cookies.set(C.auth, j.token);
   window.location.href = '/home';
   return;
 }
 
-async function handleFissionAuth({ authorise, authScenario, signIn }) {
-  if (authScenario === webnative.Scenario.AuthSucceeded || authScenario === webnative.Scenario.Continuation) {
-    return await signIn();
-  } else {
-    authorise('account-setup');
-  }
-}
-
-function SignUpPage(props: any) {
+function AccountSetupPage(props: any) {
   const [state, setState] = React.useState({
     inviteCode: '',
     username: '',
     password: '',
     loading: false,
-    fissionLoading: false,
+    fs: null,
   });
-  const { authorise, authScenario, signIn } = useFissionAuth();
+  const { fs, publish, readToken, username } = useFissionAuth();
 
   React.useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -118,46 +148,39 @@ function SignUpPage(props: any) {
     if (!U.isEmpty(inviteCode)) {
       setState({ ...state, inviteCode });
     }
+
+    async function checkForToken() {
+      const token = await readToken();
+      if (token) {
+        window.location.href = '/authed-with-fission';
+      }
+    }
+    checkForToken();
   }, []);
 
+  /** Check for token
+   * The user may already have an account. If we have a token stored for
+   * them, redirect them to the Authed with Fission interstitial page
+   */
+
+  React.useEffect(() => {
+    async function checkForToken() {
+      const token = await readToken();
+      if (token) {
+        window.location.href = '/authed-with-fission';
+      }
+    }
+    checkForToken();
+  }, [fs]);
+
   return (
-    <Page title="Estuary: Sign up" description="Create an account on Estuary with an invite key." url="https://estuary.tech/sign-up">
-      <Navigation active="SIGN_UP" />
+    <Page title="Estuary: Account Setup" description="Setup an account on Estuary with an invite key." url="https://estuary.tech/account-setup">
       <SingleColumnLayout style={{ maxWidth: 488 }}>
-        <H2>Sign up</H2>
-        <P style={{ marginTop: 16 }}>You can create an account to use Estuary if you have an invite key.</P>
+        <H2>Account Setup</H2>
+        <P style={{ marginTop: 16 }}>Welcome back! You can create an account to use Estuary if you have an invite key.</P>
+        <P style={{ marginTop: 16 }}>{username ? `You are signed into Fission as ${username}.` : 'One moment, we are loading your Fission account.'}</P>
 
-        <H3 style={{ marginTop: 32 }}>Want a Filecoin address?</H3>
-        <P style={{ marginTop: 16 }}>Sign in with Fission to create an account and make a Filecoin address.</P>
-        <Button
-          style={{
-            width: '100%',
-            marginTop: 12,
-            background: 'var(--main-button-background-fission)',
-          }}
-          loading={state.fissionLoading ? state.fissionLoading : undefined}
-          onClick={async () => {
-            // Show loading state only if user is authed, otherwise we will be redirecting
-            if (authScenario === webnative.Scenario.AuthSucceeded || authScenario === webnative.Scenario.Continuation) {
-              setState({ ...state, fissionLoading: true });
-            }
-            const response = await handleFissionAuth({
-              authorise,
-              authScenario,
-              signIn,
-            });
-            if (response && response.error) {
-              alert(response.error);
-              setState({ ...state, fissionLoading: false });
-            }
-          }}
-        >
-          Sign in with Fission
-        </Button>
-        <aside className={styles.formAside}>{state.fissionLoading ? 'We found an existing Estuary account. Signing you in now.' : ''}</aside>
-
-        <H3 style={{ marginTop: 32 }}>Create an account</H3>
-        <H4 style={{ marginTop: 16 }}>Username</H4>
+        <H4 style={{ marginTop: 32 }}>Username</H4>
         <Input
           style={{ marginTop: 8 }}
           placeholder="Type in your desired username"
@@ -193,6 +216,8 @@ function SignUpPage(props: any) {
               password: state.password,
               username: state.username,
               inviteCode: state.inviteCode,
+              fs,
+              publish,
             });
             if (response && response.error) {
               alert(response.error);
@@ -210,7 +235,7 @@ function SignUpPage(props: any) {
 
         <div className={styles.actions}>
           <Button
-            style={{ width: '100%' }}
+            style={username ? { width: '100%' } : { width: '100%', backgroundColor: '#aaaaaa' }}
             loading={state.loading ? state.loading : undefined}
             onClick={async () => {
               setState({ ...state, loading: true });
@@ -218,6 +243,8 @@ function SignUpPage(props: any) {
                 password: state.password,
                 username: state.username,
                 inviteCode: state.inviteCode,
+                fs,
+                publish,
               });
               if (response && response.error) {
                 alert(response.error);
@@ -225,18 +252,7 @@ function SignUpPage(props: any) {
               }
             }}
           >
-            Sign up
-          </Button>
-          <Button
-            style={{
-              width: '100%',
-              marginTop: 12,
-              background: 'var(--main-button-background-secondary)',
-              color: 'var(--main-button-text-secondary)',
-            }}
-            href="/sign-in"
-          >
-            Sign in instead
+            Set up account
           </Button>
         </div>
         <aside className={styles.formAside} style={{ marginTop: 8, display: 'block' }}>
@@ -251,4 +267,4 @@ function SignUpPage(props: any) {
   );
 }
 
-export default SignUpPage;
+export default AccountSetupPage;

--- a/pages/authed-with-fission.tsx
+++ b/pages/authed-with-fission.tsx
@@ -1,0 +1,66 @@
+import styles from '@pages/app.module.scss';
+
+import * as React from 'react';
+import * as U from '@common/utilities';
+
+import { useFissionAuth } from '@common/useFissionAuth';
+
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
+import Button from '@components/Button';
+
+import { H1, H2, H3, H4, P } from '@components/Typography';
+
+export async function getServerSideProps(context) {
+  const viewer = await U.getViewerFromHeader(context.req.headers);
+
+  if (viewer) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/home',
+      },
+    };
+  }
+
+  return {
+    props: { viewer },
+  };
+}
+
+function AuthedWithFissionPage(props: any) {
+  const [state, setState] = React.useState({
+    loading: false,
+    fs: null,
+  });
+  const { signIn, username } = useFissionAuth();
+
+  return (
+    <Page title="Estuary: Authenticated with Fission" description="Authenticated with Fission. Continue to Estuary" url="https://estuary.tech/authed-with-fission">
+      <SingleColumnLayout style={{ maxWidth: 488 }}>
+        <H2>Authenticated with Fission</H2>
+        <P style={{ marginTop: 16 }}>{username ? `Welcome back! You are signed into Fission as ${username}.` : 'One moment, we are loading your Fission account.'}</P>
+
+        <div className={styles.actions}>
+          <Button
+            style={username ? { width: '100%' } : { width: '100%', backgroundColor: '#aaaaaa' }}
+            loading={state.loading ? state.loading : undefined}
+            onClick={async () => {
+              setState({ ...state, loading: true });
+              const response = await signIn();
+              if (response && response.error) {
+                alert(response.error);
+                setState({ ...state, loading: false });
+              }
+            }}
+          >
+            Continue to Estuary
+          </Button>
+          <aside className={styles.formAside}>{state.loading ? 'One moment, we are signing you into Estuary with Fission.' : ''}</aside>
+        </div>
+      </SingleColumnLayout>
+    </Page>
+  );
+}
+
+export default AuthedWithFissionPage;

--- a/pages/authed-with-fission.tsx
+++ b/pages/authed-with-fission.tsx
@@ -13,6 +13,8 @@ import { H1, H2, H3, H4, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
+  const host = context.req.headers.host;
+  const protocol = host.split(':')[0] === 'localhost' ? 'http' : 'https';
 
   if (viewer) {
     return {
@@ -24,7 +26,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer },
+    props: { viewer, host, protocol },
   };
 }
 
@@ -33,7 +35,7 @@ function AuthedWithFissionPage(props: any) {
     loading: false,
     fs: null,
   });
-  const { signIn, username } = useFissionAuth();
+  const { signIn, username } = useFissionAuth({ host: props.host, protocol: props.protocol });
 
   return (
     <Page title="Estuary: Authenticated with Fission" description="Authenticated with Fission. Continue to Estuary" url="https://estuary.tech/authed-with-fission">

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -23,8 +23,6 @@ export async function getServerSideProps(context) {
   const host = context.req.headers.host;
   const protocol = host.split(':')[0] === 'localhost' ? 'http' : 'https';
 
-  console.log(protocol)
-
   if (viewer) {
     return {
       redirect: {

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -6,7 +6,7 @@ import * as C from '@common/constants';
 import * as R from '@common/requests';
 import * as Crypto from '@common/crypto';
 
-import * as webnative from 'webnative';
+import * as Webnative from 'webnative';
 import { useFissionAuth } from '@common/useFissionAuth';
 
 import Cookies from 'js-cookie';
@@ -121,7 +121,7 @@ async function handleSignIn(state: any) {
 }
 
 async function handleFissionAuth({ authorise, authScenario, signIn }) {
-  if (authScenario === webnative.Scenario.AuthSucceeded || authScenario === webnative.Scenario.Continuation) {
+  if (authScenario === Webnative.Scenario.AuthSucceeded || authScenario === Webnative.Scenario.Continuation) {
     return await signIn();
   } else {
     authorise('authed-with-fission');
@@ -149,7 +149,7 @@ function SignInPage(props: any) {
           loading={state.fissionLoading ? state.fissionLoading : undefined}
           onClick={async () => {
             // Show loading state only if user is authed, otherwise we will be redirecting
-            if (authScenario === webnative.Scenario.AuthSucceeded || authScenario === webnative.Scenario.Continuation) {
+            if (authScenario === Webnative.Scenario.AuthSucceeded || authScenario === Webnative.Scenario.Continuation) {
               setState({ ...state, fissionLoading: true });
             }
             const response = await handleFissionAuth({

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -6,6 +6,9 @@ import * as C from '@common/constants';
 import * as R from '@common/requests';
 import * as Crypto from '@common/crypto';
 
+import * as webnative from 'webnative';
+import { useFissionAuth } from '@common/useFissionAuth';
+
 import Cookies from 'js-cookie';
 import Page from '@components/Page';
 import Navigation from '@components/Navigation';
@@ -113,16 +116,55 @@ async function handleSignIn(state: any) {
   return;
 }
 
+async function handleFissionAuth({ authorise, authScenario, signIn }) {
+  if (authScenario === webnative.Scenario.AuthSucceeded || authScenario === webnative.Scenario.Continuation) {
+    return await signIn();
+  } else {
+    authorise('authed-with-fission');
+  }
+}
+
 function SignInPage(props: any) {
-  const [state, setState] = React.useState({ loading: false, username: '', password: '', key: '' });
+  const [state, setState] = React.useState({ loading: false, fissionLoading: false, username: '', password: '', key: '' });
+  const { authorise, signIn, authScenario } = useFissionAuth();
 
   return (
     <Page title="Estuary: Sign in" description="Sign in to your Estuary account." url="https://estuary.tech/sign-in">
       <Navigation active="SIGN_IN" />
       <SingleColumnLayout style={{ maxWidth: 488 }}>
         <H2>Sign in</H2>
-        <P style={{ marginTop: 16 }}>If you have created an account with Estuary before, you can use your username and password to sign in.</P>
 
+        <H3 style={{ marginTop: 16 }}>Sign in with Fission</H3>
+        <P style={{ marginTop: 8 }}>Sign in here if you created your account with Fission.</P>
+        <Button
+          style={{
+            width: '100%',
+            marginTop: 12,
+            background: 'var(--main-button-background-fission)',
+          }}
+          loading={state.fissionLoading ? state.fissionLoading : undefined}
+          onClick={async () => {
+            // Show loading state only if user is authed, otherwise we will be redirecting
+            if (authScenario === webnative.Scenario.AuthSucceeded || authScenario === webnative.Scenario.Continuation) {
+              setState({ ...state, fissionLoading: true });
+            }
+            const response = await handleFissionAuth({
+              authorise,
+              authScenario,
+              signIn,
+            });
+            if (response && response.error) {
+              alert(response.error);
+              setState({ ...state, fissionLoading: false });
+            }
+          }}
+        >
+          Sign in with Fission
+        </Button>
+        <aside className={styles.formAside}>{state.fissionLoading ? 'One moment, we are signing you in with Fission.' : ''}</aside>
+
+        <H3 style={{ marginTop: 32 }}>Sign in</H3>
+        <P style={{ marginTop: 16 }}>If you have created an account with Estuary before, you can use your username and password to sign in.</P>
         <H4 style={{ marginTop: 32 }}>Username</H4>
         <Input
           style={{ marginTop: 8 }}
@@ -178,7 +220,7 @@ function SignInPage(props: any) {
           </Button>
         </div>
 
-        <H3 style={{ marginTop: 64 }}>Authenticate Using Key</H3>
+        <H3 style={{ marginTop: 32 }}>Authenticate Using Key</H3>
         <P style={{ marginTop: 8 }}>You can authenticate using an API key if you have one.</P>
 
         <H4 style={{ marginTop: 32 }}>API key</H4>

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -20,6 +20,10 @@ import { H1, H2, H3, H4, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
+  const host = context.req.headers.host;
+  const protocol = host.split(':')[0] === 'localhost' ? 'http' : 'https';
+
+  console.log(protocol)
 
   if (viewer) {
     return {
@@ -31,7 +35,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: {},
+    props: { host, protocol },
   };
 }
 
@@ -126,7 +130,7 @@ async function handleFissionAuth({ authorise, authScenario, signIn }) {
 
 function SignInPage(props: any) {
   const [state, setState] = React.useState({ loading: false, fissionLoading: false, username: '', password: '', key: '' });
-  const { authorise, signIn, authScenario } = useFissionAuth();
+  const { authorise, signIn, authScenario } = useFissionAuth({ host: props.host, protocol: props.protocol });
 
   return (
     <Page title="Estuary: Sign in" description="Sign in to your Estuary account." url="https://estuary.tech/sign-in">

--- a/pages/sign-up.tsx
+++ b/pages/sign-up.tsx
@@ -5,7 +5,7 @@ import * as U from '@common/utilities';
 import * as C from '@common/constants';
 import * as Crypto from '@common/crypto';
 
-import * as webnative from 'webnative';
+import * as Webnative from 'webnative';
 import { useFissionAuth } from '@common/useFissionAuth';
 
 import Cookies from 'js-cookie';
@@ -96,7 +96,7 @@ async function handleRegister(state: any) {
 }
 
 async function handleFissionAuth({ authorise, authScenario, signIn }) {
-  if (authScenario === webnative.Scenario.AuthSucceeded || authScenario === webnative.Scenario.Continuation) {
+  if (authScenario === Webnative.Scenario.AuthSucceeded || authScenario === Webnative.Scenario.Continuation) {
     return await signIn();
   } else {
     authorise('account-setup');
@@ -139,8 +139,8 @@ function SignUpPage(props: any) {
           }}
           loading={state.fissionLoading ? state.fissionLoading : undefined}
           onClick={async () => {
-            // Show loading state only if user is authed, otherwise we will be redirecting
-            if (authScenario === webnative.Scenario.AuthSucceeded || authScenario === webnative.Scenario.Continuation) {
+            // NOTE(bgins): Show loading state only if user is authed, otherwise we will be redirecting
+            if (authScenario === Webnative.Scenario.AuthSucceeded || authScenario === Webnative.Scenario.Continuation) {
               setState({ ...state, fissionLoading: true });
             }
             const response = await handleFissionAuth({

--- a/pages/sign-up.tsx
+++ b/pages/sign-up.tsx
@@ -19,6 +19,8 @@ import { H1, H2, H3, H4, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
+  const host = context.req.headers.host;
+  const protocol = host.split(':')[0] === 'localhost' ? 'http' : 'https';
 
   if (viewer) {
     return {
@@ -30,7 +32,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer },
+    props: { viewer, host, protocol },
   };
 }
 
@@ -109,7 +111,7 @@ function SignUpPage(props: any) {
     loading: false,
     fissionLoading: false,
   });
-  const { authorise, authScenario, signIn } = useFissionAuth();
+  const { authorise, authScenario, signIn } = useFissionAuth({ host: props.host, protocol: props.protocol });
 
   React.useEffect(() => {
     const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
This pull request adds Fission auth alongisde the current Estuary auth system.  The new authentication system leverages the current API key system.

We should probably treat this PR as a draft because more work is needed before it add value.

### Auth with Fission flows

The summary outline describes how authentication with Fission works as currently implemented in this PR.

**Sign Up**
- User does not have a Fission account
  + Redirect to Fission Auth Lobby where they grant permission to use their storage and the fil-cosigner key
  + Redirect back to a new interstitial "Account Setup" page
  + User signs up as usual with username, password, and invite code (maybe we can not require a password here?)
  + Two tokens are requested
    - One that is set as a cookie in the usual way
    - A second one is stored in WNFS for the next time the user signs in. This token is stored encrypted at rest.
    - We do this because the first token will be invalidated when the user signs out
  + Redirect to the user's home page
- User has an Estuary account and is signed in with Fission
  + Read the token from WNFS and set it as a cookie to authenticate the user
  + Request a second token for next time and replace the stored token with it
  + Redirect to the user's home page
- User has an Estuary account and is not signed into Fission
  + Redirect to Fission Auth Lobby where they grant permission to use their storage and the fil-cosigner key
  + Redirect back to the new interstitial "Account Setup" page
    - Look for the user's stored token. They have one, so redirect to a new "Authed with Fission" interstitial page
    - This second redirect isn't ideal, but we can't know if the user had a stored token before we authenticate them
  + User clicks a "Contiue to Estuary" button
    - Another token is requested and swapped out as above
  + Redirect to the user's home page

**Sign In**
- User has an Estuary account and is signed in with Fission
  + Read the token from WNFS and set it as a cookie to authenticate the user
  + Request a second token for next time and replace the stored token with it
  + Redirect to the user's home page
- User has an Estuary account and is not signed into Fission
  + Redirect to Fission Auth Lobby where they grant permission to use their storage and the fil-cosigner key
  + Redirect back to the new interstitial "Authed with Fission" page
  + User clicks a "Contiue to Estuary" button
    - Another token is requested and swapped out as above
  + Redirect to the user's home page

In cases where a user attempts sign in without a stored token they are shown an alert with an error message.

### Implementation
#### Buttons

New buttons have been added for sign up and sign in with Fission :sparkles: 

#### Sign in and sign up pages

Fission auth has been added to `pages/sign-up.tsx` and `pages/sign-in.tsx`.

#### Interstitial pages

The pages `pages/account-setup.tsx` and `pages/authed-with-fission.tsx` have been added to handle cases where a user is returning from the Fission Auth Lobby. 

#### `useFissionAuth` hook

Most of the interactions with `webnative` are handled here, with the exception of the initial sign up.

#### FIL wallets

Not quite yet! This PR has parts of the wallet story in place. More pieces are in progress to set up user wallets.


