### PR TITLE
Fix miner rename button

### DIFF
--- a/pages/your-miners.tsx
+++ b/pages/your-miners.tsx
@@ -131,7 +131,7 @@ function YourMinerPage(props: any) {
                                 return;
                               }
 
-                              const response = await R.put(`/user/miner/set-info/${answer}`, { name: answer });
+                              const response = await R.put(`/user/miner/set-info/${data}`, { name: answer });
 
                               if (response && response.error) {
                                 return alert(response.error);


### PR DESCRIPTION
Discovered while trying to rename the miner i just added and took control of. I think the only problem here is the URL is based on the address rather than the name. Based on the other URL's used, I believe this is what's needed.