### PR TITLE
Use relative path for verify-cid href

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -32,7 +32,7 @@ const Navigation = (props: any) => {
             </a>
           ) : null}
 
-          <a href="https://estuary.tech/verify-cid" className={styles.webItem}>
+          <a href="/verify-cid" className={styles.webItem}>
             Verify
           </a>
 


### PR DESCRIPTION
Given the `verify-cid` URI is dependent on the root domain, it's best to change it to a relative path. This will make it easy for testings this endpoint irrespective of the application environment (dev/prod). Right now, if you run this application on your dev machine, the `verify-cid` points to the prod link (which is not useful given CID generated locally to the best of my knowledge, will not be verified)