### PR TITLE
Bug: Properly check deal exist on chain when verifying CID

### DIFF
--- a/pages/verify-cid.tsx
+++ b/pages/verify-cid.tsx
@@ -222,7 +222,7 @@ function VerifyCIDPage(props: any) {
             </React.Fragment>
           )}
 
-          {state.data && state.data.deals ? (
+          {state.data && state.data.deals && state.data.deals.length > 0 ? (
             <React.Fragment>
               <div className={S.scustom} style={{ marginTop: 48 }}>
                 <H3>✅ This CID is sealed on Filecoin</H3>


### PR DESCRIPTION
When CID is verified, we should check the length of the deals is more than 0. The response from the API to verify a CID always sends a deals field, so checking if it exists is not enough. This fix will stop the UI from misleading users when they actually haven't made any deals for a CID.

Before this fix
<img width="541" alt="Screenshot 2022-05-04 at 20 11 50" src="https://user-images.githubusercontent.com/13554411/166808924-4a03f952-4190-439c-aff1-dbf139819239.png">

After this fix
<img width="669" alt="Screenshot 2022-05-04 at 20 12 30" src="https://user-images.githubusercontent.com/13554411/166808970-73d0ba6b-0d1e-4a8a-97e7-80aa681642e4.png">

This closes https://github.com/application-research/estuary-www/issues/30