### PR TITLE
display bucket size in storage unit

### DIFF
--- a/pages/staging.tsx
+++ b/pages/staging.tsx
@@ -98,7 +98,7 @@ function StagingPage(props) {
                     <th className={tstyles.th}>Max items</th>
                   </tr>
                   <tr className={tstyles.tr}>
-                    <td className={tstyles.td}>{U.formatNumber(bucket.curSize)}</td>
+                    <td className={tstyles.td}>{U.bytesToSize(bucket.curSize)}</td>
                     <td className={tstyles.td}>{U.bytesToSize(bucket.maxSize)}</td>
                     <td className={tstyles.td}>{U.bytesToSize(bucket.minSize)}</td>
                     <td className={tstyles.td}>{U.formatNumber(bucket.maxItems)}</td>


### PR DESCRIPTION
The staging bucket `size` on the UI does not currently display in the storage unit (`GiB`) like the staging min/max sizes. This PR will make sure the unit is properly displayed and make it intuitive for users to understand where they are on how much data is staged vs the requirements.

The UI before this fix
<img width="1253" alt="Screenshot 2022-05-05 at 09 09 24" src="https://user-images.githubusercontent.com/13554411/166885043-f6740953-cdf2-433c-aa21-e5991dd086e5.png">

The UI after this fix
<img width="1249" alt="Screenshot 2022-05-05 at 09 07 59" src="https://user-images.githubusercontent.com/13554411/166885074-9da5e9bd-1e16-4678-a7dd-deaa3a313ccb.png">

