### PR TITLE
use content replication over settings replication on deals UI

### DIFF
--- a/pages/deals/index.tsx
+++ b/pages/deals/index.tsx
@@ -128,16 +128,16 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
           </span>
         ) : null}
       </div>
-      {viewer && viewer.settings ? (
+      {content && content.replication ? (
         <React.Fragment>
-          {successCount === viewer.settings.replication ? (
+          {successCount === content.replication ? (
             <div className={styles.titleSection} style={{ backgroundColor: `var(--status-success-bright)`, fontFamily: 'MonoMedium' }}>
               Your data is backed up to the Filecoin Network
             </div>
           ) : (
             <div className={styles.titleSection} style={{ fontFamily: 'MonoMedium' }}>
               <LoaderSpinner style={{ border: `2px solid rgba(0, 0, 0, 0.1)`, borderTop: `2px solid #000` }} />
-              &nbsp; Estuary is working on {viewer.settings.replication} successful on chain deals. {successCount} / {viewer.settings.replication}
+              &nbsp; Estuary is working on {content.replication} successful on chain deals. {successCount} / {content.replication}
             </div>
           )}
         </React.Fragment>


### PR DESCRIPTION
Currently, the deals UI uses the settings replication and not the content replication. The content replication is the granular replication value used to maintain deals count. This PR will fix it to use the actual content replication. 

I noticed this bug when I change replication count when running estuary, I expected the different contents to have their replication counts maintained depending on the `--replication` flag or the `replication` param when the content is created - they did not, the UI kept showing the default instead of the content replication.

Before the fix - this content has a replication of 2 but kept showing 6;
<img width="1246" alt="Screenshot 2022-05-23 at 14 26 52" src="https://user-images.githubusercontent.com/13554411/169830832-ba8c8719-9304-4885-aa55-39800a2023c5.png">

After the fix - UI is now showing the right replication count - 2
<img width="1251" alt="Screenshot 2022-05-23 at 14 27 07" src="https://user-images.githubusercontent.com/13554411/169830932-551e7c0c-3755-492d-985b-7a898b70746a.png">
