### PR TITLE
chore: revert filename change

### DIFF
--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -147,8 +147,8 @@ function HomePage(props: any) {
                     const fileURL = `https://dweb.link/ipfs/${data.cid['/']}`;
 
                     let name = '...';
-                    if (data && data.filename) {
-                      name = data.filename;
+                    if (data && data.name) {
+                      name = data.name;
                     }
                     if (name === 'aggregate') {
                       name = '/';

--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -102,7 +102,7 @@ function UploadCIDPage(props: any) {
                   `/content/add-ipfs`,
                   {
                     filename: state.filename,
-                    filename: state.cid,
+                    root: state.cid,
                   },
                   props.api
                 );

--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -101,7 +101,7 @@ function UploadCIDPage(props: any) {
                 const response = await R.post(
                   `/content/add-ipfs`,
                   {
-                    filename: state.filename,
+                    name: state.filename,
                     root: state.cid,
                   },
                   props.api
@@ -138,7 +138,7 @@ function UploadCIDPage(props: any) {
                   const response = await R.post(
                     `/content/add-ipfs`,
                     {
-                      filename: state.filename,
+                      name: state.filename,
                       root: state.cid,
                     },
                     props.api

--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -101,8 +101,8 @@ function UploadCIDPage(props: any) {
                 const response = await R.post(
                   `/content/add-ipfs`,
                   {
-                    name: state.filename,
-                    root: state.cid,
+                    filename: state.filename,
+                    filename: state.cid,
                   },
                   props.api
                 );


### PR DESCRIPTION
# Changes

The change in the `Content` field would force us to rebuild the `contents` table and given that this field mapping is just for naming convenience (using filename instead of name) without any major functionality introduced, we should revert and just use the same field name. 

This PR reverts all the changes we did to rename the `name` field to `filename`.

# Related PR
https://github.com/application-research/estuary/pull/389

# Verification
## estuary-www
![image](https://user-images.githubusercontent.com/4479171/182964787-3ac0e621-fbb5-4985-a37d-8e9aa00e6b3b.png)