### PR TITLE
patch: remove 2 logos

### DIFF
--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -176,14 +176,6 @@ function EcosystemPage(props: any) {
               style={{ height: 48, flexShrink: 0, display: 'inlineFlex', margin: 22 }}
             />
             <img
-              src="https://user-images.githubusercontent.com/310223/155955136-d41a6bb7-f808-44b2-891e-ebbad7d3e21a.png"
-              style={{ height: 48, flexShrink: 0, display: 'inlineFlex', margin: 22 }}
-            />
-            <img
-              src="https://user-images.githubusercontent.com/310223/155955145-274a768d-eec4-4dcf-9435-0af7ea2595ff.png"
-              style={{ height: 48, flexShrink: 0, display: 'inlineFlex', margin: 22 }}
-            />
-            <img
               src="https://user-images.githubusercontent.com/310223/156037345-f93054de-d222-47e9-9653-cd957fc0fcc5.svg"
               style={{ height: 48, flexShrink: 0, display: 'inlineFlex', margin: 22 }}
             />


### PR DESCRIPTION
<img width="1466" alt="Screen Shot 2022-08-05 at 3 50 45 PM" src="https://user-images.githubusercontent.com/104923168/183142442-357134a7-f4e6-4c74-8f8b-ed8b1daf223a.png">

- I removed logos for both nft.storage and web3.storage