### PR TITLE
fix: null case of verifiedClientBalance in balance page

### DIFF
--- a/pages/admin/balance.tsx
+++ b/pages/admin/balance.tsx
@@ -108,7 +108,7 @@ function AdminBalancePage(props) {
             {U.inFIL(state.balance)}
           </Block>
           <Block style={{ marginTop: 2 }} label="Verified data cap">
-            {U.bytesToSize(state.verifiedClientBalance)}
+            {state.verifiedClientBalance !== null ? U.bytesToSize(state.verifiedClientBalance) : 0}
           </Block>
 
           <H3 style={{ marginTop: 56 }}>Move Filecoin into Estuary Escrow</H3>


### PR DESCRIPTION
Trying to fix this error. 
After datacap is exhausted we get verifiedClientBalance as null from the balance API. 

![Untitled](https://user-images.githubusercontent.com/4976460/185349865-7345620c-53f3-4e3a-b80b-f4aef1ef9447.jpg)
