### PR TITLE
Added a Copy button to the estuary invites table

### DIFF
--- a/pages/admin/invites.tsx
+++ b/pages/admin/invites.tsx
@@ -138,7 +138,21 @@ function AdminInvitesPage(props: any) {
                 ? state.invites.map((data, index) => {
                     return (
                       <tr key={data.code} className={tstyles.tr} style={{ opacity: !U.isEmpty(data.claimedBy) ? 0.2 : 1 }}>
-                        <td className={tstyles.td}>https://{window.location.hostname}/sign-up?invite={data.code}</td>
+                        <td className={tstyles.td}>
+                          <div>
+                            https://{window.location.hostname}/sign-up?invite={data.code}{' '}
+                            <button
+                              style={{ float: 'right', opacity: 0.5, outline: 'None', fontFamily: 'mono', marginRight: '1rem' }}
+                              onClick={(e) => {
+                                navigator.clipboard.writeText(`https://${window.location.hostname}/sign-up?invite=${data.code}`);
+                                e.target.textContent = 'Copied!';
+                                setTimeout((e) => (e.target.textContent = 'Copy'), 1000, e);
+                              }}
+                            >
+                              Copy
+                            </button>
+                          </div>
+                        </td>
                         <td className={tstyles.td}>{data.createdBy}</td>
                         <td className={tstyles.td}>{data.claimedBy}</td>
                       </tr>


### PR DESCRIPTION
Added a copy button to the estuary invites table to make it easier to copy and send out estuary invites.

<img width="1288" alt="image" src="https://user-images.githubusercontent.com/9143795/194106718-0551a92d-47c3-4c36-86f7-c4e998cd0ce0.png">
