### PR TITLE
Fixed estuary invite links on localhost

### DIFF
--- a/pages/admin/invites.tsx
+++ b/pages/admin/invites.tsx
@@ -140,11 +140,11 @@ function AdminInvitesPage(props: any) {
                       <tr key={data.code} className={tstyles.tr} style={{ opacity: !U.isEmpty(data.claimedBy) ? 0.2 : 1 }}>
                         <td className={tstyles.td}>
                           <div>
-                            https://{window.location.hostname}/sign-up?invite={data.code}{' '}
+                            https://{window.location.host}/sign-up?invite={data.code}{' '}
                             <button
                               style={{ float: 'right', opacity: 0.5, outline: 'None', fontFamily: 'mono', marginRight: '1rem' }}
                               onClick={(e) => {
-                                navigator.clipboard.writeText(`https://${window.location.hostname}/sign-up?invite=${data.code}`);
+                                navigator.clipboard.writeText(`https://${window.location.host}/sign-up?invite=${data.code}`);
                                 e.target.textContent = 'Copied!';
                                 setTimeout((e) => (e.target.textContent = 'Copy'), 1000, e);
                               }}

--- a/pages/admin/invites.tsx
+++ b/pages/admin/invites.tsx
@@ -136,15 +136,16 @@ function AdminInvitesPage(props: any) {
               </tr>
               {state.invites && state.invites.length
                 ? state.invites.map((data, index) => {
+                    const inviteLink = window.location.hostname === 'localhost' ?  `http://${window.location.host}/sign-up?invite=${data.code}` : `https://${window.location.hostname}/sign-up?invite=${data.code}`;
                     return (
                       <tr key={data.code} className={tstyles.tr} style={{ opacity: !U.isEmpty(data.claimedBy) ? 0.2 : 1 }}>
                         <td className={tstyles.td}>
                           <div>
-                            https://{window.location.host}/sign-up?invite={data.code}{' '}
+                            {inviteLink}{' '}
                             <button
                               style={{ float: 'right', opacity: 0.5, outline: 'None', fontFamily: 'mono', marginRight: '1rem' }}
                               onClick={(e) => {
-                                navigator.clipboard.writeText(`https://${window.location.host}/sign-up?invite=${data.code}`);
+                                navigator.clipboard.writeText(inviteLink);
                                 e.target.textContent = 'Copied!';
                                 setTimeout((e) => (e.target.textContent = 'Copy'), 1000, e);
                               }}


### PR DESCRIPTION
Added logic to generate invite links differently if the project is running on localhost. 

Local host invite links now use this format:
`http://${window.location.host}/sign-up?invite=${data.code}`

<img width="1283" alt="image" src="https://user-images.githubusercontent.com/9143795/194121839-41575bca-0f53-40e4-951d-417585709997.png">
