### PR TITLE
chore: reverted the cli-auth changes

### DIFF
--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -68,14 +68,8 @@ async function handleSignIn(state: any, host) {
     return { error: 'Your username must be 1-48 characters or digits.' };
   }
 
-  if(state.adminLogin == 'true'){
-    state.passwordHash = state.password;
-  }else {
-    // NOTE(jim) We've added a new scheme to keep things safe for users.
-    state.passwordHash = await Crypto.attemptHashWithSalt(state.password);
-  }
-
-
+  // NOTE(jim) We've added a new scheme to keep things safe for users.
+  state.passwordHash = await Crypto.attemptHashWithSalt(state.password);
 
   let r = await fetch(`${host}/login`, {
     method: 'POST',
@@ -147,7 +141,7 @@ async function handleSignIn(state: any, host) {
 function SignInPage(props: any) {
 
 
-  const [state, setState] = React.useState({ loading: false, authLoading: false, fissionLoading: false, username: '', password: '', key: '', adminLogin: 'false' });
+  const [state, setState] = React.useState({ loading: false, authLoading: false, fissionLoading: false, username: '', password: '', key: '' });
 
   const authorise = null;
   const authScenario = null;
@@ -187,21 +181,7 @@ function SignInPage(props: any) {
           }}
         />
 
-        <div className={styles.actions} style={{ marginTop: 10 }}>
-          <input
-            type="checkbox"
-            onClick={() => {
-              if (state.adminLogin === 'false') {
-                setState({ ...state, adminLogin: 'true' });
-              } else {
-                setState({ ...state, adminLogin: 'false' });
-              }
-            }}
-          /><p style={{ fontSize:12, marginTop:1 }}>This user was created using estuary CLI</p>
-        </div>
-
         <div className={styles.actions}>
-
           <Button
             style={{ width: '100%' }}
             loading={state.loading ? state.loading : undefined}


### PR DESCRIPTION
# Changes
I noticed that the sign-in page from cli-auth was committed along with the webmint PR https://github.com/application-research/estuary-www/pull/68. As per our discussion, this shouldn't be included for now pending any further discussion on how to improve the use of salt on the frontend.

