### PR TITLE
Show FIL address in Balance page even before account has a balance

### DIFF
--- a/pages/admin/balance.tsx
+++ b/pages/admin/balance.tsx
@@ -29,31 +29,32 @@ const sendEscrow = async (state, setState, host) => {
 
   if (response.error) {
     alert('Something went wrong, please try again.');
-    setState({ ...state, loading: false, amount: 0 });
+    setState({ ...state, amount: 0, loading: false });
     return;
   }
 
-  await getBalance(state, setState, host);
+  let newState = await getBalance(state, host);
+  setState({ ...state, ...newState, amount: 0, loading: false });
 };
 
-const getFilAddress = async (state, setState, host) => {
+const getFilAddress = async (state, host) => {
   const response = await R.get('/admin/fil-address', host);
   if (response.error) {
     console.log(response.error);
     return;
   }
 
-  setState({ ...state, account: response });
+  return { ...state, account: response };
 };
 
-const getBalance = async (state, setState, host) => {
+const getBalance = async (state, host) => {
   const response = await R.get('/admin/balance', host);
   if (response.error) {
     console.log(response.error);
     return;
   }
 
-  setState({ ...state, ...response, amount: 0, loading: false });
+  return { ...state, ...response };
 };
 
 export async function getServerSideProps(context) {
@@ -96,8 +97,10 @@ function AdminBalancePage(props) {
 
   React.useEffect(() => {
     const run = async () => {
-      getFilAddress(state, setState, props.api);
-      getBalance(state, setState, props.api);
+      let newState = { account: null, amount: 0, loading: false };
+      newState = await getFilAddress(newState, props.api);
+      newState = await getBalance(newState, props.api);
+      setState({ ...state, ...newState });
     };
 
     run();

--- a/pages/admin/balance.tsx
+++ b/pages/admin/balance.tsx
@@ -36,6 +36,16 @@ const sendEscrow = async (state, setState, host) => {
   await getBalance(state, setState, host);
 };
 
+const getFilAddress = async (state, setState, host) => {
+  const response = await R.get('/admin/fil-address', host);
+  if (response.error) {
+    console.log(response.error);
+    return;
+  }
+
+  setState({ ...state, account: response });
+};
+
 const getBalance = async (state, setState, host) => {
   const response = await R.get('/admin/balance', host);
   if (response.error) {
@@ -86,6 +96,7 @@ function AdminBalancePage(props) {
 
   React.useEffect(() => {
     const run = async () => {
+      getFilAddress(state, setState, props.api);
       getBalance(state, setState, props.api);
     };
 

--- a/pages/admin/balance.tsx
+++ b/pages/admin/balance.tsx
@@ -41,7 +41,7 @@ const getFilAddress = async (state, host) => {
   const response = await R.get('/admin/fil-address', host);
   if (response.error) {
     console.log(response.error);
-    return;
+    return state;
   }
 
   return { ...state, account: response };
@@ -51,7 +51,7 @@ const getBalance = async (state, host) => {
   const response = await R.get('/admin/balance', host);
   if (response.error) {
     console.log(response.error);
-    return;
+    return state;
   }
 
   return { ...state, ...response };


### PR DESCRIPTION
**Problem**: When setting up a new estuary node, you can’t find your FIL address through the estuary-www UI because the /admin/balance endpoint fails until the address has a balance. This creates friction if you miss the FIL address in the CLI output, creating friction in getting your account funded.

**Proposed Solution**: Use a dedicated /admin/fil-address endpoint so we can always display the FIL address in the Balance page. (PR to add endpoint: https://github.com/application-research/estuary/pull/476)

### Before
![image](https://user-images.githubusercontent.com/2850013/196770611-f692604b-4c7b-4635-914a-205d03798c25.png)

### After
![image](https://user-images.githubusercontent.com/2850013/196770514-8820bf9b-5dac-4133-9e3e-db7f6612580c.png)

**Note**: Safe to merge regardless of timing with https://github.com/application-research/estuary/pull/476 (console will see a 404 if merged out of order), but functionality is dependent on that PR.
