### PR TITLE
chore: generate retrieval links for non-aggregate cids

### DIFF
--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -34,7 +34,11 @@ const FilesTable = ({ files }) => {
 
       {
         Header: 'Retrieval Link',
-        accessor: (data) => `https://dweb.link/ipfs/${data.cid['/']}`,
+        accessor: (data) => {
+          if (data.name !== 'aggregate') {
+            return `https://dweb.link/ipfs/${data.cid['/']}`
+          }
+        },
         Cell: ({ value }) => (
           <a href={value} target="_blank" className={tstyles.cta}>
             {value}


### PR DESCRIPTION
# Changes

Discovered this bug during my test of the new API endpoint. We only need to generate the retrieval link for non-aggregated CIDs.

# Note
We need this fix as part of 0.1.10 release. Any users with aggregated CID will see a blank page if we don't have this.