### PR TITLE
Use context api host instead of prod api for key mgmt

### DIFF
--- a/common/requests.ts
+++ b/common/requests.ts
@@ -2,7 +2,7 @@ import Cookies from 'js-cookie';
 
 import * as C from '@common/constants';
 
-export const get = async (route, host = 'https://api.estuary.tech'): Promise<any> => {
+export const get = async (route, host = C.api.host): Promise<any> => {
   try {
     const token = Cookies.get(C.auth);
 
@@ -36,7 +36,7 @@ export const get = async (route, host = 'https://api.estuary.tech'): Promise<any
   }
 };
 
-export const post = async (route, payload, host = 'https://api.estuary.tech'): Promise<any> => {
+export const post = async (route, payload, host = C.api.host): Promise<any> => {
   try {
     const token = Cookies.get(C.auth);
 
@@ -71,7 +71,7 @@ export const post = async (route, payload, host = 'https://api.estuary.tech'): P
   }
 };
 
-export const put = async (route, payload, host = 'https://api.estuary.tech'): Promise<any> => {
+export const put = async (route, payload, host = C.api.host): Promise<any> => {
   try {
     const token = Cookies.get(C.auth);
 
@@ -106,7 +106,7 @@ export const put = async (route, payload, host = 'https://api.estuary.tech'): Pr
   }
 };
 
-export const del = async (route: string, payload?: object, host = 'https://api.estuary.tech'): Promise<any> => {
+export const del = async (route: string, payload?: object, host = C.api.host): Promise<any> => {
   try {
     const token = Cookies.get(C.auth);
 


### PR DESCRIPTION
Key mgmt APIs were hardcoded to hit api.estuary.tech which prevented key mgmt page from working on localhost in dev mode. This also leads to excess 401s on our prod API.