### PR TITLE
[Discussion] Use strn.pl instead of dweb.link as gateway?

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,10 +2,10 @@ The contents of this repository are Copyright (c) corresponding authors and
 contributors, licensed under the `Permissive License Stack` meaning either of:
 
 - Apache-2.0 Software License: https://www.apache.org/licenses/LICENSE-2.0
-  ([...4tr2kfsq](https://dweb.link/ipfs/bafkreiankqxazcae4onkp436wag2lj3ccso4nawxqkkfckd6cg4tr2kfsq))
+  ([...4tr2kfsq](https://strn.pl/ipfs/bafkreiankqxazcae4onkp436wag2lj3ccso4nawxqkkfckd6cg4tr2kfsq))
 
 - MIT Software License: https://opensource.org/licenses/MIT
-  ([...vljevcba](https://dweb.link/ipfs/bafkreiepofszg4gfe2gzuhojmksgemsub2h4uy2gewdnr35kswvljevcba))
+  ([...vljevcba](https://strn.pl/ipfs/bafkreiepofszg4gfe2gzuhojmksgemsub2h4uy2gewdnr35kswvljevcba))
 
 You may not use the contents of this repository except in compliance
 with one of the listed Licenses. For an extended clarification of the

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -56,3 +56,5 @@ function getAPIHost(): string {
 export const api = {
   host: getAPIHost(),
 };
+
+export const gateway = "https://strn.pl";

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -2,6 +2,8 @@ import tstyles from '@pages/table.module.scss';
 import { useMemo } from 'react';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 
+import * as C from '@common/constants';
+
 const FilesTable = ({ files }) => {
   const columns = useMemo(
     () => [
@@ -36,7 +38,7 @@ const FilesTable = ({ files }) => {
         Header: 'Retrieval Link',
         accessor: (data) => {
           if (data.name !== 'aggregate') {
-            return `https://dweb.link/ipfs/${data.cid['/']}`
+            return `${C.gateway}/ipfs/${data.cid['/']}`;
           }
         },
         Cell: ({ value }) => (

--- a/components/UploadItem.tsx
+++ b/components/UploadItem.tsx
@@ -120,13 +120,13 @@ export default class UploadItem extends React.Component<any> {
 
     xhr.onloadend = (event: any) => {
       if (!event.target || !event.target.response) {
-        return
+        return;
       }
-      
+
       startTime = null;
       secondsElapsed = 0;
       if (event.target.status === 200) {
-        let json = {}
+        let json = {};
         try {
           json = JSON.parse(event.target.response);
         } catch (e) {
@@ -172,7 +172,9 @@ export default class UploadItem extends React.Component<any> {
             <ActionRow isHeading style={{ fontSize: '0.9rem', fontWeight: 500, background: `var(--status-success-bright)` }}>
               {this.props.file.data.name} uploaded to our node!
             </ActionRow>
-            <ActionRow>https://dweb.link/ipfs/{this.state.final.cid}</ActionRow>
+            <ActionRow>
+              ${C.gateway}/ipfs/{this.state.final.cid}
+            </ActionRow>
             {maybePinStatusElement}
             {this.props.file.estimation ? (
               <ActionRow style={{ background: `var(--status-success-bright)` }}>Filecoin Deals are being mmade for {this.props.file.data.name}.</ActionRow>

--- a/pages/admin/content.tsx
+++ b/pages/admin/content.tsx
@@ -94,7 +94,7 @@ function AdminContentPage(props: any) {
               </tr>
               {state.content && state.content.length
                 ? state.content.map((data, index) => {
-                    const fileURL = `https://dweb.link/ipfs/${data.cid}`;
+                    const fileURL = `${C.gateway}/ipfs/${data.cid}`;
                     return (
                       <tr className={tstyles.tr} key={`${data.id}-${data.name}-${data.cid}`}>
                         <td className={tstyles.td}>{data.name === 'aggregate' ? '/' : data.name}</td>

--- a/pages/admin/content.tsx
+++ b/pages/admin/content.tsx
@@ -3,6 +3,7 @@ import tstyles from '@pages/table.module.scss';
 
 import * as React from 'react';
 import * as U from '@common/utilities';
+import * as C from '@common/constants';
 import * as R from '@common/requests';
 
 import Navigation from '@components/Navigation';

--- a/pages/deals/[id].tsx
+++ b/pages/deals/[id].tsx
@@ -44,7 +44,7 @@ function DealPage(props: any) {
 
   let fileURL;
   if (state.transfer) {
-    fileURL = `https://dweb.link/ipfs/${state.transfer.baseCid}`;
+    fileURL = `${C.gateway}/ipfs/${state.transfer.baseCid}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} active="DEAL_BY_ID" />;

--- a/pages/deals/[id].tsx
+++ b/pages/deals/[id].tsx
@@ -3,6 +3,7 @@ import tstyles from '@pages/table.module.scss';
 
 import * as React from 'react';
 import * as U from '@common/utilities';
+import * as C from '@common/constants';
 import * as R from '@common/requests';
 
 import Navigation from '@components/Navigation';

--- a/pages/deals/index.tsx
+++ b/pages/deals/index.tsx
@@ -66,7 +66,7 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
       <div className={styles.empty}>Estuary has not performed any deals for this file, yet.</div>
     );
 
-  const retrievalURL = content ? `https://dweb.link/ipfs/${content.cid}` : null;
+  const retrievalURL = content ? `${C.gateway}/ipfs/${content.cid}` : null;
 
   let name = '...';
   if (content && content.name) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -341,7 +341,7 @@ function IndexPage(props: any) {
             </div>
 
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://dweb.link/ipfs/QmSX2wCbAeMVXB3Gdfd23MnLW5wxpzE41dG7W1S4d5RXPi" target="_blank">
+              <a className={styles.actionButtonLink} href="${C.gateway}/ipfs/QmSX2wCbAeMVXB3Gdfd23MnLW5wxpzE41dG7W1S4d5RXPi" target="_blank">
                 Try it ➝
               </a>
             </div>

--- a/pages/proposals/[cid].tsx
+++ b/pages/proposals/[cid].tsx
@@ -3,6 +3,7 @@ import tstyles from '@pages/table.module.scss';
 
 import * as React from 'react';
 import * as U from '@common/utilities';
+import * as C from '@common/constants';
 import * as R from '@common/requests';
 
 import Navigation from '@components/Navigation';

--- a/pages/proposals/[cid].tsx
+++ b/pages/proposals/[cid].tsx
@@ -44,7 +44,7 @@ function ProposalPage(props: any) {
 
   let fileURL;
   if (state.deal) {
-    fileURL = `https://dweb.link/ipfs/${state.deal.Label}`;
+    fileURL = `${C.gateway}/ipfs/${state.deal.Label}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} />;

--- a/pages/receipts/[id].tsx
+++ b/pages/receipts/[id].tsx
@@ -44,7 +44,7 @@ function ReceiptPage(props) {
 
   let fileURL;
   if (state.deal) {
-    fileURL = `https://dweb.link/ipfs/${state.deal.Label}`;
+    fileURL = `${C.gateway}/ipfs/${state.deal.Label}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} />;

--- a/pages/receipts/[id].tsx
+++ b/pages/receipts/[id].tsx
@@ -3,6 +3,7 @@ import tstyles from '@pages/table.module.scss';
 
 import * as React from 'react';
 import * as U from '@common/utilities';
+import * as C from '@common/constants';
 import * as R from '@common/requests';
 
 import Navigation from '@components/Navigation';

--- a/pages/staging.tsx
+++ b/pages/staging.tsx
@@ -3,6 +3,7 @@ import tstyles from '@pages/table.module.scss';
 
 import * as React from 'react';
 import * as U from '@common/utilities';
+import * as C from '@common/constants';
 import * as R from '@common/requests';
 
 import ProgressCard from '@components/ProgressCard';
@@ -129,7 +130,7 @@ function StagingPage(props) {
                     </tr>
 
                     {bucket.contents.map((data, index) => {
-                      const fileURL = `https://dweb.link/ipfs/${data.cid}`;
+                      const fileURL = `${C.gateway}/ipfs/${data.cid}`;
                       return (
                         <tr key={`${data.cid['/']}-${index}`} className={tstyles.tr}>
                           <td className={tstyles.td} style={{ fontSize: 12, fontFamily: 'Mono', opacity: 0.4 }}>

--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -76,8 +76,8 @@ function UploadCIDPage(props: any) {
             {U.isEmpty(state.cid) ? null : (
               <aside className={styles.formAside}>
                 Check your CID:{' '}
-                <a href={`https://dweb.link/ipfs/${state.cid}`} target="_blank">
-                  https://dweb.link/ipfs/{state.cid}
+                <a href={`${C.gateway}/ipfs/${state.cid}`} target="_blank">
+                  ${C.gateway}/ipfs/{state.cid}
                 </a>
                 .
               </aside>

--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -3,6 +3,7 @@ import tstyles from '@pages/table.module.scss';
 
 import * as React from 'react';
 import * as U from '@common/utilities';
+import * as C from '@common/constants';
 import * as R from '@common/requests';
 
 import Navigation from '@components/Navigation';

--- a/pages/verify-cid.tsx
+++ b/pages/verify-cid.tsx
@@ -199,8 +199,8 @@ function VerifyCIDPage(props: any) {
               {statusElement}
               <StatRow title="CID">{state.data.content.cid}</StatRow>
               <StatRow title="Retrieval URL">
-                <a href={`https://dweb.link/ipfs/${state.data.content.cid}`} target="_blank">
-                  https://dweb.link/ipfs/{state.data.content.cid}
+                <a href={`${C.gateway}/ipfs/${state.data.content.cid}`} target="_blank">
+                  ${C.gateway}/ipfs/{state.data.content.cid}
                 </a>
               </StatRow>
               <StatRow title="Estuary Node ID">{state.data.content.id}</StatRow>
@@ -215,8 +215,8 @@ function VerifyCIDPage(props: any) {
               {statusElement}
 
               <StatRow title="Retrieval URL">
-                <a href={`https://dweb.link/ipfs/${state.cid.trim()}`} target="_blank">
-                  https://dweb.link/ipfs/{state.cid.trim()}
+                <a href={`${C.gateway}/ipfs/${state.cid.trim()}`} target="_blank">
+                  ${C.gateway}/ipfs/{state.cid.trim()}
                 </a>
               </StatRow>
             </React.Fragment>
@@ -253,7 +253,8 @@ function VerifyCIDPage(props: any) {
                         dealId={d.dealId}
                         cid={state.data.content.cid}
                         aggregatedIn={state.data.aggregatedIn?.cid}
-                        selector={state.data.selector} />
+                        selector={state.data.selector}
+                      />
                     </StatRow>
                   </div>
                 );
@@ -274,7 +275,7 @@ function VerifyCIDPage(props: any) {
 
       <div className={S.stats}>
         <div className={S.sc}>
-          <div className={S.scn}>{state.totalFilesStored ? state.totalFilesStored.toLocaleString() : "0"}</div>
+          <div className={S.scn}>{state.totalFilesStored ? state.totalFilesStored.toLocaleString() : '0'}</div>
           <div className={S.scl}>Total files</div>
         </div>
         <div className={S.sc}>

--- a/pages/verify-cid.tsx
+++ b/pages/verify-cid.tsx
@@ -2,6 +2,7 @@ import S from '@pages/index.module.scss';
 
 import * as React from 'react';
 import * as U from '@common/utilities';
+import * as C from '@common/constants';
 import * as R from '@common/requests';
 
 import Page from '@components/Page';


### PR DESCRIPTION
Opening the discussion of switching over the estuary-www preferred gateway to leverage Saturn.

Did some simple tests and found strn.pl to be anecdotally faster than dweb.link, but slower than api.estuary.tech/gw for new estuary uploads. I still need to test uploading new content via estuary and seeing how Saturn does in fetching it, particularly on first retrieval.

Another option is simply using api.estuary.tech/gw as the preferred gateway, which should be the most performant choice for first retrieval, but wouldn't get the caching benefits of Saturn and means the links could break if estuary was down. 

Expanding on this – could we get Saturn to very quickly find estuary's gateways to improve speed when Saturn's L1 has a cache miss (i.e. first retrieval)? This would then make strn.pl a clear ideal choice for the preferred gateway on estuary-www, to me at least. One idea is having estuary gateways colocate a Saturn L1/L2 node, but this could result in the gateways caching a lot of files irrelevant to estuary users. If the level of customization allows it, we could potentially only cache estuary files on our node and preemptively write them to cache as part of an estuary upload.

Note: It seems still TBD how to handle clients that make requests directly to Saturn without payment: See "The client doesn’t pay directly for retrievals" on https://filecoin.io/blog/posts/retrieval-markets-rollup-h1-2022/. This is likely worth discussing with Saturn.