### PR TITLE
change docs to github hosted estuary-documentation

### DIFF
--- a/components/AuthenticatedSidebar.tsx
+++ b/components/AuthenticatedSidebar.tsx
@@ -49,7 +49,7 @@ function AuthenticatedLayout(props: any) {
       <a className={styles.item} href="/settings">
         Account
       </a>
-      <a className={styles.item} href="https://docs.estuary.tech/feedback" target="_blank">
+      <a className={styles.item} href="https://application-research.github.io/estuary-documentation/feedback" target="_blank">
         Feedback
       </a>
       <span

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -36,7 +36,7 @@ const Navigation = (props: any) => {
             Verify
           </a>
 
-          <a href="https://docs.estuary.tech" className={styles.webItem}>
+          <a href="https://application-research.github.io/estuary-documentation/" className={styles.webItem}>
             Documentation
           </a>
 

--- a/pages/comparisons-web3.tsx
+++ b/pages/comparisons-web3.tsx
@@ -192,7 +192,7 @@ function ComparisonsWeb3Page(props: any) {
 
         <div className={S.actions}>
           <Button
-            href="https://docs.estuary.tech/feedback"
+            href="https://application-research.github.io/estuary-documentation/feedback"
             target="_blank"
             style={{
               background: `var(--main-primary)`,

--- a/pages/comparisons.tsx
+++ b/pages/comparisons.tsx
@@ -192,7 +192,7 @@ function ComparisonPage(props: any) {
 
         <div className={S.actions}>
           <Button
-            href="https://docs.estuary.tech/feedback"
+            href="https://application-research.github.io/estuary-documentation/feedback"
             target="_blank"
             style={{
               background: `var(--main-primary)`,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -158,7 +158,7 @@ function IndexPage(props: any) {
             <button
               className={styles.actionButton}
               onClick={() => {
-                window.location.href = 'https://docs.estuary.tech/get-invite-key';
+                window.location.href = 'https://application-research.github.io/estuary-documentation/get-invite-key';
               }}
             >
               Get an invite ➝
@@ -167,7 +167,7 @@ function IndexPage(props: any) {
             <button
               className={styles.actionButton}
               onClick={() => {
-                window.location.href = 'https://docs.estuary.tech/get-provider-added';
+                window.location.href = 'https://application-research.github.io/estuary-documentation/get-provider-added';
               }}
             >
               Apply to provide storage ➝
@@ -195,7 +195,7 @@ function IndexPage(props: any) {
             <button
               className={styles.actionButton}
               onClick={() => {
-                window.location.href = 'https://docs.estuary.tech/get-provider-added';
+                window.location.href = 'https://application-research.github.io/estuary-documentation/get-provider-added';
               }}
             >
               Apply to provide storage ➝
@@ -253,7 +253,7 @@ function IndexPage(props: any) {
             </div>
 
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://docs.estuary.tech" target="_blank">
+              <a className={styles.actionButtonLink} href="https://application-research.github.io/estuary-documentation/" target="_blank">
                 Read docs ➝
               </a>
             </div>
@@ -356,7 +356,7 @@ function IndexPage(props: any) {
               <p className={styles.p}>Check our FAQ for answers to your questions</p>
             </div>
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://docs.estuary.tech/faq" target="_blank">
+              <a className={styles.actionButtonLink} href="https://application-research.github.io/estuary-documentation/Learn/faq" target="_blank">
                 Read FAQ ➝
               </a>
             </div>
@@ -371,7 +371,7 @@ function IndexPage(props: any) {
               <p className={styles.p}>Do you have questions about Estuary? Ask your question using this form, everyone on the team will see it.</p>
             </div>
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://docs.estuary.tech/feedback" target="_blank">
+              <a className={styles.actionButtonLink} href="https://application-research.github.io/estuary-documentation/feedback" target="_blank">
                 Give feedback ➝
               </a>
             </div>
@@ -469,7 +469,7 @@ function IndexPage(props: any) {
               <p className={styles.p}>Want to follow a step by step guide to learn how to use Estuary? Try our tutorial.</p>
             </div>
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://docs.estuary.tech/tutorial-get-an-api-key" target="_blank">
+              <a className={styles.actionButtonLink} href="https://application-research.github.io/estuary-documentation/Tutorial/tutorial-get-an-api-key" target="_blank">
                 View tutorial ➝
               </a>
             </div>

--- a/pages/sign-up.tsx
+++ b/pages/sign-up.tsx
@@ -199,7 +199,7 @@ function SignUpPage(props: any) {
         />
         <aside className={styles.formAside}>
           Need an invite key?{' '}
-          <a href="https://docs.estuary.tech" target="_blank">
+          <a href="https://application-research.github.io/estuary-documentation/Learn/get-invite-key" target="_blank">
             Learn how to get one.
           </a>
           .
@@ -242,7 +242,7 @@ function SignUpPage(props: any) {
         </div>
         <aside className={styles.formAside} style={{ marginTop: 8, display: 'block' }}>
           By creating an account or by using Estuary you unconditionally agree to our{' '}
-          <a href="https://docs.estuary.tech/terms" target="_blank">
+          <a href="https://application-research.github.io/estuary-documentation/terms" target="_blank">
             Terms of Service
           </a>
           .


### PR DESCRIPTION
long term we can change to a new URL but this PR gets our new documentation live on the gh pages host url https://application-research.github.io/estuary-documentation