### PR TITLE
Show both estuary and dweb retrieval urls

### DIFF
--- a/common/utilities.ts
+++ b/common/utilities.ts
@@ -4,6 +4,14 @@ import * as Cookies from '@vendor/cookie-cutter';
 import * as C from '@common/constants';
 import * as R from '@common/requests';
 
+export const formatEstuaryRetrievalUrl = (cid: string) => {
+  return `${C.api.host}/gw/ipfs/${cid}`
+}
+
+export const formatDwebRetrievalUrl = (cid: string) => {
+  return `https://dweb.link/ipfs/${cid}`
+}
+
 export const nanoToHours = (number: any): string => {
   const ms = Number(number) / 1000000;
   return (Number(ms) / (1000 * 60 * 60)).toFixed(1);

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -2,6 +2,8 @@ import tstyles from '@pages/table.module.scss';
 import { useMemo } from 'react';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 
+import * as C from '@common/constants';
+
 const FilesTable = ({ files }) => {
   const columns = useMemo(
     () => [
@@ -36,7 +38,7 @@ const FilesTable = ({ files }) => {
         Header: 'Retrieval Link',
         accessor: (data) => {
           if (data.name !== 'aggregate') {
-            return `https://dweb.link/ipfs/${data.cid['/']}`
+            return `${C.api.host}/gw/ipfs/${data.cid['/']}`;
           }
         },
         Cell: ({ value }) => (

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -35,7 +35,7 @@ const FilesTable = ({ files }) => {
       },
 
       {
-        Header: 'Retrieval url',
+        Header: 'Estuary retrieval url',
         accessor: (data) => {
           if (data.name !== 'aggregate') {
             return `${C.api.host}/gw/ipfs/${data.cid['/']}`;

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -2,7 +2,7 @@ import tstyles from '@pages/table.module.scss';
 import { useMemo } from 'react';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 
-import * as C from '@common/constants';
+import * as U from '@common/utilities';
 
 const FilesTable = ({ files }) => {
   const columns = useMemo(
@@ -38,7 +38,7 @@ const FilesTable = ({ files }) => {
         Header: 'Estuary retrieval url',
         accessor: (data) => {
           if (data.name !== 'aggregate') {
-            return `${C.api.host}/gw/ipfs/${data.cid['/']}`;
+            return U.formatEstuaryRetrievalUrl(data.cid['/']);
           }
         },
         Cell: ({ value }) => (
@@ -55,7 +55,7 @@ const FilesTable = ({ files }) => {
         Header: 'Dweb retrieval url',
         accessor: (data) => {
           if (data.name !== 'aggregate') {
-            return `https://dweb.link/ipfs/${data.cid['/']}`;
+            return U.formatDwebRetrievalUrl(data.cid['/']);
           }
         },
         Cell: ({ value }) => (

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -35,10 +35,27 @@ const FilesTable = ({ files }) => {
       },
 
       {
-        Header: 'Retrieval Link',
+        Header: 'Retrieval url',
         accessor: (data) => {
           if (data.name !== 'aggregate') {
             return `${C.api.host}/gw/ipfs/${data.cid['/']}`;
+          }
+        },
+        Cell: ({ value }) => (
+          <a href={value} target="_blank" className={tstyles.cta}>
+            {value}
+          </a>
+        ),
+        width: '55%',
+        maxWidth: '55%',
+        Filter: DefaultColumnFilter,
+      },
+
+      {
+        Header: 'Dweb retrieval url',
+        accessor: (data) => {
+          if (data.name !== 'aggregate') {
+            return `https://dweb.link/ipfs/${data.cid['/']}`;
           }
         },
         Cell: ({ value }) => (

--- a/components/UploadItem.tsx
+++ b/components/UploadItem.tsx
@@ -120,13 +120,13 @@ export default class UploadItem extends React.Component<any> {
 
     xhr.onloadend = (event: any) => {
       if (!event.target || !event.target.response) {
-        return
+        return;
       }
-      
+
       startTime = null;
       secondsElapsed = 0;
       if (event.target.status === 200) {
-        let json = {}
+        let json = {};
         try {
           json = JSON.parse(event.target.response);
         } catch (e) {
@@ -172,7 +172,9 @@ export default class UploadItem extends React.Component<any> {
             <ActionRow isHeading style={{ fontSize: '0.9rem', fontWeight: 500, background: `var(--status-success-bright)` }}>
               {this.props.file.data.name} uploaded to our node!
             </ActionRow>
-            <ActionRow>https://dweb.link/ipfs/{this.state.final.cid}</ActionRow>
+            <ActionRow>
+              {C.api.host}/gw/ipfs/{this.state.final.cid}
+            </ActionRow>
             {maybePinStatusElement}
             {this.props.file.estimation ? (
               <ActionRow style={{ background: `var(--status-success-bright)` }}>Filecoin Deals are being mmade for {this.props.file.data.name}.</ActionRow>

--- a/components/UploadItem.tsx
+++ b/components/UploadItem.tsx
@@ -177,6 +177,11 @@ export default class UploadItem extends React.Component<any> {
                 {C.api.host}/gw/{this.state.final.cid}
               </a>
             </ActionRow>
+            <ActionRow>
+              <a href={`https://dweb.link/ipfs/${this.state.final.cid}`} target="_blank">
+                https://dweb.link/{this.state.final.cid}
+              </a>
+            </ActionRow>
             {maybePinStatusElement}
             {this.props.file.estimation ? (
               <ActionRow style={{ background: `var(--status-success-bright)` }}>Filecoin Deals are being mmade for {this.props.file.data.name}.</ActionRow>

--- a/components/UploadItem.tsx
+++ b/components/UploadItem.tsx
@@ -165,6 +165,9 @@ export default class UploadItem extends React.Component<any> {
       maybePinStatusElement = <PinStatusElement id={this.state.final.estuaryId} host={this.props.host} />;
     }
 
+    const estuaryRetrievalUrl = this.state.final ? U.formatEstuaryRetrievalUrl(this.state.final.cid) : null;
+    const dwebRetrievalUrl = this.state.final ? U.formatDwebRetrievalUrl(this.state.final.cid) : null;
+
     return (
       <section className={styles.item}>
         {this.state.final ? (
@@ -173,13 +176,13 @@ export default class UploadItem extends React.Component<any> {
               {this.props.file.data.name} uploaded to our node!
             </ActionRow>
             <ActionRow>
-              <a href={`${C.api.host}/gw/ipfs/${this.state.final.cid}`} target="_blank">
-                {C.api.host}/gw/{this.state.final.cid}
+              <a href={estuaryRetrievalUrl} target="_blank">
+                {estuaryRetrievalUrl}
               </a>
             </ActionRow>
             <ActionRow>
-              <a href={`https://dweb.link/ipfs/${this.state.final.cid}`} target="_blank">
-                https://dweb.link/{this.state.final.cid}
+              <a href={dwebRetrievalUrl} target="_blank">
+                {dwebRetrievalUrl}
               </a>
             </ActionRow>
             {maybePinStatusElement}

--- a/components/UploadItem.tsx
+++ b/components/UploadItem.tsx
@@ -173,7 +173,9 @@ export default class UploadItem extends React.Component<any> {
               {this.props.file.data.name} uploaded to our node!
             </ActionRow>
             <ActionRow>
-              {C.api.host}/gw/ipfs/{this.state.final.cid}
+              <a href={`${C.api.host}/gw/ipfs/${this.state.final.cid}`} target="_blank">
+                {C.api.host}/gw/{this.state.final.cid}
+              </a>
             </ActionRow>
             {maybePinStatusElement}
             {this.props.file.estimation ? (

--- a/pages/admin/content.tsx
+++ b/pages/admin/content.tsx
@@ -1,22 +1,17 @@
 import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
-import * as C from '@common/constants';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 import PageHeader from '@components/PageHeader';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import Block from '@components/Block';
-import Input from '@components/Input';
-import Button from '@components/Button';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -95,8 +90,8 @@ function AdminContentPage(props: any) {
               </tr>
               {state.content && state.content.length
                 ? state.content.map((data, index) => {
-                    const estuaryRetrievalUrl = `${C.api.host}/gw/ipfs/${data.cid}`;
-                    const dwebRetrievalUrl = `https://dweb.link/ipfs/${data.cid}`;
+                    const estuaryRetrievalUrl = U.formatEstuaryRetrievalUrl(data.cid);
+                    const dwebRetrievalUrl = U.formatDwebRetrievalUrl(data.cid);
                     return (
                       <tr className={tstyles.tr} key={`${data.id}-${data.name}-${data.cid}`}>
                         <td className={tstyles.td}>{data.name === 'aggregate' ? '/' : data.name}</td>

--- a/pages/admin/content.tsx
+++ b/pages/admin/content.tsx
@@ -96,6 +96,7 @@ function AdminContentPage(props: any) {
               {state.content && state.content.length
                 ? state.content.map((data, index) => {
                     const fileURL = `${C.api.host}/gw/ipfs/${data.cid}`;
+                    const dwebURL = `https://dweb.link/ipfs/${data.cid}`;
                     return (
                       <tr className={tstyles.tr} key={`${data.id}-${data.name}-${data.cid}`}>
                         <td className={tstyles.td}>{data.name === 'aggregate' ? '/' : data.name}</td>
@@ -109,6 +110,9 @@ function AdminContentPage(props: any) {
                         <td className={tstyles.tdcta}>
                           <a href={fileURL} target="_blank" className={tstyles.cta}>
                             {fileURL}
+                          </a>
+                          <a href={dwebURL} target="_blank" className={tstyles.cta}>
+                            {dwebURL}
                           </a>
                         </td>
                         <td className={tstyles.td}>{data.replication} times</td>

--- a/pages/admin/content.tsx
+++ b/pages/admin/content.tsx
@@ -95,8 +95,8 @@ function AdminContentPage(props: any) {
               </tr>
               {state.content && state.content.length
                 ? state.content.map((data, index) => {
-                    const fileURL = `${C.api.host}/gw/ipfs/${data.cid}`;
-                    const dwebURL = `https://dweb.link/ipfs/${data.cid}`;
+                    const estuaryRetrievalUrl = `${C.api.host}/gw/ipfs/${data.cid}`;
+                    const dwebRetrievalUrl = `https://dweb.link/ipfs/${data.cid}`;
                     return (
                       <tr className={tstyles.tr} key={`${data.id}-${data.name}-${data.cid}`}>
                         <td className={tstyles.td}>{data.name === 'aggregate' ? '/' : data.name}</td>
@@ -108,11 +108,11 @@ function AdminContentPage(props: any) {
                         </td>
 
                         <td className={tstyles.tdcta}>
-                          <a href={fileURL} target="_blank" className={tstyles.cta}>
-                            {fileURL}
+                          <a href={estuaryRetrievalUrl} target="_blank" className={tstyles.cta}>
+                            {estuaryRetrievalUrl}
                           </a>
-                          <a href={dwebURL} target="_blank" className={tstyles.cta}>
-                            {dwebURL}
+                          <a href={dwebRetrievalUrl} target="_blank" className={tstyles.cta}>
+                            {dwebRetrievalUrl}
                           </a>
                         </td>
                         <td className={tstyles.td}>{data.replication} times</td>

--- a/pages/admin/content.tsx
+++ b/pages/admin/content.tsx
@@ -4,6 +4,7 @@ import tstyles from '@pages/table.module.scss';
 import * as React from 'react';
 import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as C from '@common/constants';
 
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
@@ -94,7 +95,7 @@ function AdminContentPage(props: any) {
               </tr>
               {state.content && state.content.length
                 ? state.content.map((data, index) => {
-                    const fileURL = `https://dweb.link/ipfs/${data.cid}`;
+                    const fileURL = `${C.api.host}/gw/ipfs/${data.cid}`;
                     return (
                       <tr className={tstyles.tr} key={`${data.id}-${data.name}-${data.cid}`}>
                         <td className={tstyles.td}>{data.name === 'aggregate' ? '/' : data.name}</td>

--- a/pages/deals/[id].tsx
+++ b/pages/deals/[id].tsx
@@ -43,12 +43,8 @@ function DealPage(props: any) {
     run();
   }, []);
 
-  let estuaryRetrievalUrl;
-  let dwebRetrievalUrl;
-  if (state.transfer) {
-    estuaryRetrievalUrl = `${C.api.host}/gw/ipfs/${state.transfer.baseCid}`;
-    dwebRetrievalUrl = `https://dweb.link/ipfs/${state.transfer.baseCid}`;
-  }
+  const estuaryRetrievalUrl = state.transfer ? U.formatEstuaryRetrievalUrl(state.transfer.baseCid) : null;
+  const dwebRetrievalUrl = state.transfer ? U.formatDwebRetrievalUrl(state.transfer.baseCid) : null;
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} active="DEAL_BY_ID" />;
 

--- a/pages/deals/[id].tsx
+++ b/pages/deals/[id].tsx
@@ -44,8 +44,10 @@ function DealPage(props: any) {
   }, []);
 
   let fileURL;
+  let dwebURL;
   if (state.transfer) {
     fileURL = `${C.api.host}/gw/ipfs/${state.transfer.baseCid}`;
+    dwebURL = `https://dweb.link/ipfs/${state.transfer.baseCid}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} active="DEAL_BY_ID" />;
@@ -126,7 +128,7 @@ function DealPage(props: any) {
             <table className={tstyles.table}>
               <tbody className={tstyles.tbody}>
                 <tr className={tstyles.tr}>
-                  <th className={tstyles.th}>Base CID + retrieval link</th>
+                  <th className={tstyles.th}>Estuary retrieval url</th>
                 </tr>
 
                 <tr className={tstyles.tr}>
@@ -134,6 +136,26 @@ function DealPage(props: any) {
                     <td className={tstyles.tdcta}>
                       <a className={tstyles.cta} href={fileURL} target="_blank">
                         {fileURL}
+                      </a>
+                    </td>
+                  ) : (
+                    <td className={tstyles.td}>Does not exist</td>
+                  )}
+                </tr>
+              </tbody>
+            </table>
+
+            <table className={tstyles.table}>
+              <tbody className={tstyles.tbody}>
+                <tr className={tstyles.tr}>
+                  <th className={tstyles.th}>Dweb retrieval url</th>
+                </tr>
+
+                <tr className={tstyles.tr}>
+                  {!U.isEmpty(dwebURL) ? (
+                    <td className={tstyles.tdcta}>
+                      <a className={tstyles.cta} href={dwebURL} target="_blank">
+                        {dwebURL}
                       </a>
                     </td>
                   ) : (

--- a/pages/deals/[id].tsx
+++ b/pages/deals/[id].tsx
@@ -4,6 +4,7 @@ import tstyles from '@pages/table.module.scss';
 import * as React from 'react';
 import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as C from '@common/constants';
 
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
@@ -44,7 +45,7 @@ function DealPage(props: any) {
 
   let fileURL;
   if (state.transfer) {
-    fileURL = `https://dweb.link/ipfs/${state.transfer.baseCid}`;
+    fileURL = `${C.api.host}/gw/ipfs/${state.transfer.baseCid}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} active="DEAL_BY_ID" />;

--- a/pages/deals/[id].tsx
+++ b/pages/deals/[id].tsx
@@ -43,11 +43,11 @@ function DealPage(props: any) {
     run();
   }, []);
 
-  let fileURL;
-  let dwebURL;
+  let estuaryRetrievalUrl;
+  let dwebRetrievalUrl;
   if (state.transfer) {
-    fileURL = `${C.api.host}/gw/ipfs/${state.transfer.baseCid}`;
-    dwebURL = `https://dweb.link/ipfs/${state.transfer.baseCid}`;
+    estuaryRetrievalUrl = `${C.api.host}/gw/ipfs/${state.transfer.baseCid}`;
+    dwebRetrievalUrl = `https://dweb.link/ipfs/${state.transfer.baseCid}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} active="DEAL_BY_ID" />;
@@ -132,10 +132,10 @@ function DealPage(props: any) {
                 </tr>
 
                 <tr className={tstyles.tr}>
-                  {!U.isEmpty(fileURL) ? (
+                  {!U.isEmpty(estuaryRetrievalUrl) ? (
                     <td className={tstyles.tdcta}>
-                      <a className={tstyles.cta} href={fileURL} target="_blank">
-                        {fileURL}
+                      <a className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
+                        {estuaryRetrievalUrl}
                       </a>
                     </td>
                   ) : (
@@ -152,10 +152,10 @@ function DealPage(props: any) {
                 </tr>
 
                 <tr className={tstyles.tr}>
-                  {!U.isEmpty(dwebURL) ? (
+                  {!U.isEmpty(dwebRetrievalUrl) ? (
                     <td className={tstyles.tdcta}>
-                      <a className={tstyles.cta} href={dwebURL} target="_blank">
-                        {dwebURL}
+                      <a className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
+                        {dwebRetrievalUrl}
                       </a>
                     </td>
                   ) : (

--- a/pages/deals/index.tsx
+++ b/pages/deals/index.tsx
@@ -66,8 +66,8 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
       <div className={styles.empty}>Estuary has not performed any deals for this file, yet.</div>
     );
 
-  const retrievalURL = content ? `${C.api.host}/gw/ipfs/${content.cid}` : null;
-  const dwebRetrievalUrl = content ? `https://dweb.link/ipfs/${content.cid}` : null;
+  const estuaryRetrievalUrl = content ? U.formatEstuaryRetrievalUrl(content.cid) : null;
+  const dwebRetrievalUrl = content ? U.formatDwebRetrievalUrl(content.cid) : null;
 
   let name = '...';
   if (content && content.name) {
@@ -104,8 +104,8 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
             <td className={tstyles.td}>{name}</td>
 
             <td className={tstyles.tdcta}>
-              <a className={tstyles.cta} href={retrievalURL} target="_blank">
-                {retrievalURL}
+              <a className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
+                {estuaryRetrievalUrl}
               </a>
             </td>
 

--- a/pages/deals/index.tsx
+++ b/pages/deals/index.tsx
@@ -66,7 +66,7 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
       <div className={styles.empty}>Estuary has not performed any deals for this file, yet.</div>
     );
 
-  const retrievalURL = content ? `https://dweb.link/ipfs/${content.cid}` : null;
+  const retrievalURL = content ? `${C.api.host}/gw/ipfs/${content.cid}` : null;
 
   let name = '...';
   if (content && content.name) {

--- a/pages/deals/index.tsx
+++ b/pages/deals/index.tsx
@@ -67,7 +67,7 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
     );
 
   const retrievalURL = content ? `${C.api.host}/gw/ipfs/${content.cid}` : null;
-  const dwebURL = content ? `https://dweb.link/ipfs/${content.cid}` : null;
+  const dwebRetrievalUrl = content ? `https://dweb.link/ipfs/${content.cid}` : null;
 
   let name = '...';
   if (content && content.name) {
@@ -110,8 +110,8 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
             </td>
 
             <td className={tstyles.tdcta}>
-              <a className={tstyles.cta} href={dwebURL} target="_blank">
-                {dwebURL}
+              <a className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
+                {dwebRetrievalUrl}
               </a>
             </td>
 

--- a/pages/deals/index.tsx
+++ b/pages/deals/index.tsx
@@ -67,6 +67,7 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
     );
 
   const retrievalURL = content ? `${C.api.host}/gw/ipfs/${content.cid}` : null;
+  const dwebURL = content ? `https://dweb.link/ipfs/${content.cid}` : null;
 
   let name = '...';
   if (content && content.name) {
@@ -87,7 +88,10 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
               Name
             </th>
             <th className={tstyles.th} style={{ width: '50%' }}>
-              Retrieval CID
+              Estuary retrieval url
+            </th>
+            <th className={tstyles.th} style={{ width: '50%' }}>
+              Dweb retrieval url
             </th>
             <th className={tstyles.th} style={{ width: '12.5%' }}>
               ID
@@ -102,6 +106,12 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
             <td className={tstyles.tdcta}>
               <a className={tstyles.cta} href={retrievalURL} target="_blank">
                 {retrievalURL}
+              </a>
+            </td>
+
+            <td className={tstyles.tdcta}>
+              <a className={tstyles.cta} href={dwebURL} target="_blank">
+                {dwebURL}
               </a>
             </td>
 

--- a/pages/proposals/[cid].tsx
+++ b/pages/proposals/[cid].tsx
@@ -1,15 +1,13 @@
-import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
-import * as C from '@common/constants';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -43,12 +41,8 @@ function ProposalPage(props: any) {
     run();
   }, []);
 
-  let estuaryRetrievalUrl;
-  let dwebRetrievalUrl;
-  if (state.deal) {
-    estuaryRetrievalUrl = `${C.api.host}/gw/ipfs/${state.deal.Label}`;
-    dwebRetrievalUrl = `https://dweb.link/ipfs/${state.deal.Label}`;
-  }
+  const estuaryRetrievalUrl = state.deal ? U.formatEstuaryRetrievalUrl(state.deal.Label) : null;
+  const dwebRetrievalUrl = state.deal ? U.formatDwebRetrievalUrl(state.deal.Label) : null;
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} />;
 

--- a/pages/proposals/[cid].tsx
+++ b/pages/proposals/[cid].tsx
@@ -43,11 +43,11 @@ function ProposalPage(props: any) {
     run();
   }, []);
 
-  let fileURL;
-  let dwebURL;
+  let estuaryRetrievalUrl;
+  let dwebRetrievalUrl;
   if (state.deal) {
-    fileURL = `${C.api.host}/gw/ipfs/${state.deal.Label}`;
-    dwebURL = `https://dweb.link/ipfs/${state.deal.Label}`;
+    estuaryRetrievalUrl = `${C.api.host}/gw/ipfs/${state.deal.Label}`;
+    dwebRetrievalUrl = `https://dweb.link/ipfs/${state.deal.Label}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} />;
@@ -77,8 +77,8 @@ function ProposalPage(props: any) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={fileURL} target="_blank">
-                      {fileURL}
+                    <a className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
+                      {estuaryRetrievalUrl}
                     </a>
                   </td>
                 </tr>
@@ -93,8 +93,8 @@ function ProposalPage(props: any) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={dwebURL} target="_blank">
-                      {dwebURL}
+                    <a className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
+                      {dwebRetrievalUrl}
                     </a>
                   </td>
                 </tr>

--- a/pages/proposals/[cid].tsx
+++ b/pages/proposals/[cid].tsx
@@ -4,6 +4,7 @@ import tstyles from '@pages/table.module.scss';
 import * as React from 'react';
 import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as C from '@common/constants';
 
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
@@ -44,7 +45,7 @@ function ProposalPage(props: any) {
 
   let fileURL;
   if (state.deal) {
-    fileURL = `https://dweb.link/ipfs/${state.deal.Label}`;
+    fileURL = `${C.api.host}/gw/ipfs/${state.deal.Label}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} />;

--- a/pages/proposals/[cid].tsx
+++ b/pages/proposals/[cid].tsx
@@ -44,8 +44,10 @@ function ProposalPage(props: any) {
   }, []);
 
   let fileURL;
+  let dwebURL;
   if (state.deal) {
     fileURL = `${C.api.host}/gw/ipfs/${state.deal.Label}`;
+    dwebURL = `https://dweb.link/ipfs/${state.deal.Label}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} />;
@@ -70,13 +72,29 @@ function ProposalPage(props: any) {
             <table className={tstyles.table}>
               <tbody className={tstyles.tbody}>
                 <tr className={tstyles.tr}>
-                  <th className={tstyles.th}>CID + retrieval link</th>
+                  <th className={tstyles.th}>Estuary retrieval url</th>
                 </tr>
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
                     <a className={tstyles.cta} href={fileURL} target="_blank">
                       {fileURL}
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <table className={tstyles.table}>
+              <tbody className={tstyles.tbody}>
+                <tr className={tstyles.tr}>
+                  <th className={tstyles.th}>Dweb retrieval url</th>
+                </tr>
+
+                <tr className={tstyles.tr}>
+                  <td className={tstyles.tdcta}>
+                    <a className={tstyles.cta} href={dwebURL} target="_blank">
+                      {dwebURL}
                     </a>
                   </td>
                 </tr>

--- a/pages/receipts/[id].tsx
+++ b/pages/receipts/[id].tsx
@@ -4,6 +4,7 @@ import tstyles from '@pages/table.module.scss';
 import * as React from 'react';
 import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as C from '@common/constants';
 
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
@@ -44,7 +45,7 @@ function ReceiptPage(props) {
 
   let fileURL;
   if (state.deal) {
-    fileURL = `https://dweb.link/ipfs/${state.deal.Label}`;
+    fileURL = `${C.api.host}/gw/ipfs/${state.deal.Label}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} />;

--- a/pages/receipts/[id].tsx
+++ b/pages/receipts/[id].tsx
@@ -43,11 +43,11 @@ function ReceiptPage(props) {
     run();
   }, []);
 
-  let fileURL;
-  let dwebURL;
+  let estuaryRetrievalUrl;
+  let dwebRetrievalUrl;
   if (state.deal) {
-    fileURL = `${C.api.host}/gw/ipfs/${state.deal.Label}`;
-    dwebURL = `https://dweb.link/ipfs/${state.deal.Label}`;
+    estuaryRetrievalUrl = `${C.api.host}/gw/ipfs/${state.deal.Label}`;
+    dwebRetrievalUrl = `https://dweb.link/ipfs/${state.deal.Label}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} />;
@@ -77,8 +77,8 @@ function ReceiptPage(props) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={fileURL} target="_blank">
-                      {fileURL}
+                    <a className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
+                      {estuaryRetrievalUrl}
                     </a>
                   </td>
                 </tr>
@@ -93,8 +93,8 @@ function ReceiptPage(props) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={dwebURL} target="_blank">
-                      {dwebURL}
+                    <a className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
+                      {dwebRetrievalUrl}
                     </a>
                   </td>
                 </tr>

--- a/pages/receipts/[id].tsx
+++ b/pages/receipts/[id].tsx
@@ -43,12 +43,8 @@ function ReceiptPage(props) {
     run();
   }, []);
 
-  let estuaryRetrievalUrl;
-  let dwebRetrievalUrl;
-  if (state.deal) {
-    estuaryRetrievalUrl = `${C.api.host}/gw/ipfs/${state.deal.Label}`;
-    dwebRetrievalUrl = `https://dweb.link/ipfs/${state.deal.Label}`;
-  }
+  const estuaryRetrievalUrl = state.deal ? U.formatEstuaryRetrievalUrl(state.deal.Label) : null;
+  const dwebRetrievalUrl = state.deal ? U.formatDwebRetrievalUrl(state.deal.Label) : null;
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} />;
 

--- a/pages/receipts/[id].tsx
+++ b/pages/receipts/[id].tsx
@@ -44,8 +44,10 @@ function ReceiptPage(props) {
   }, []);
 
   let fileURL;
+  let dwebURL;
   if (state.deal) {
     fileURL = `${C.api.host}/gw/ipfs/${state.deal.Label}`;
+    dwebURL = `https://dweb.link/ipfs/${state.deal.Label}`;
   }
 
   const sidebarElement = <AuthenticatedSidebar viewer={props.viewer} />;
@@ -70,13 +72,29 @@ function ReceiptPage(props) {
             <table className={tstyles.table}>
               <tbody className={tstyles.tbody}>
                 <tr className={tstyles.tr}>
-                  <th className={tstyles.th}>CID + retrieval link</th>
+                  <th className={tstyles.th}>Estuary retrieval url</th>
                 </tr>
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
                     <a className={tstyles.cta} href={fileURL} target="_blank">
                       {fileURL}
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <table className={tstyles.table}>
+              <tbody className={tstyles.tbody}>
+                <tr className={tstyles.tr}>
+                  <th className={tstyles.th}>Dweb retrieval url</th>
+                </tr>
+
+                <tr className={tstyles.tr}>
+                  <td className={tstyles.tdcta}>
+                    <a className={tstyles.cta} href={dwebURL} target="_blank">
+                      {dwebURL}
                     </a>
                   </td>
                 </tr>

--- a/pages/staging.tsx
+++ b/pages/staging.tsx
@@ -133,8 +133,8 @@ function StagingPage(props) {
                     </tr>
 
                     {bucket.contents.map((data, index) => {
-                      const fileURL = `${C.api.host}/gw/ipfs/${data.cid}`;
-                      const dwebURL = `https://dweb.link/ipfs/${data.cid}`;
+                      const estuaryRetrievalUrl = `${C.api.host}/gw/ipfs/${data.cid}`;
+                      const dwebRetrievalUrl = `https://dweb.link/ipfs/${data.cid}`;
                       return (
                         <tr key={`${data.cid['/']}-${index}`} className={tstyles.tr}>
                           <td className={tstyles.td} style={{ fontSize: 12, fontFamily: 'Mono', opacity: 0.4 }}>
@@ -142,13 +142,13 @@ function StagingPage(props) {
                           </td>
                           <td className={tstyles.td}>{data.name}</td>
                           <td className={tstyles.tdcta}>
-                            <a href={fileURL} target="_blank" className={tstyles.cta}>
-                              {fileURL}
+                            <a href={estuaryRetrievalUrl} target="_blank" className={tstyles.cta}>
+                              {estuaryRetrievalUrl}
                             </a>
                           </td>
                           <td className={tstyles.tdcta}>
-                            <a className={tstyles.cta} href={dwebURL} target="_blank">
-                              {dwebURL}
+                            <a className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
+                              {dwebRetrievalUrl}
                             </a>
                           </td>
                           <td className={tstyles.td}>{U.bytesToSize(data.size)}</td>

--- a/pages/staging.tsx
+++ b/pages/staging.tsx
@@ -4,6 +4,7 @@ import tstyles from '@pages/table.module.scss';
 import * as React from 'react';
 import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as C from '@common/constants';
 
 import ProgressCard from '@components/ProgressCard';
 import Navigation from '@components/Navigation';
@@ -131,7 +132,7 @@ function StagingPage(props) {
                     </tr>
 
                     {bucket.contents.map((data, index) => {
-                      const fileURL = `https://dweb.link/ipfs/${data.cid}`;
+                      const fileURL = `${C.api.host}/gw/ipfs/${data.cid}`;
                       return (
                         <tr key={`${data.cid['/']}-${index}`} className={tstyles.tr}>
                           <td className={tstyles.td} style={{ fontSize: 12, fontFamily: 'Mono', opacity: 0.4 }}>

--- a/pages/staging.tsx
+++ b/pages/staging.tsx
@@ -122,7 +122,8 @@ function StagingPage(props) {
                       <th className={tstyles.th} style={{ width: '30%' }}>
                         Name
                       </th>
-                      <th className={tstyles.th}>Retrieval link</th>
+                      <th className={tstyles.th}>Estuary retrieval url</th>
+                      <th className={tstyles.th}>Dweb retrieval url</th>
                       <th className={tstyles.th} style={{ width: '104px' }}>
                         Size
                       </th>
@@ -133,6 +134,7 @@ function StagingPage(props) {
 
                     {bucket.contents.map((data, index) => {
                       const fileURL = `${C.api.host}/gw/ipfs/${data.cid}`;
+                      const dwebURL = `https://dweb.link/ipfs/${data.cid}`;
                       return (
                         <tr key={`${data.cid['/']}-${index}`} className={tstyles.tr}>
                           <td className={tstyles.td} style={{ fontSize: 12, fontFamily: 'Mono', opacity: 0.4 }}>
@@ -142,6 +144,11 @@ function StagingPage(props) {
                           <td className={tstyles.tdcta}>
                             <a href={fileURL} target="_blank" className={tstyles.cta}>
                               {fileURL}
+                            </a>
+                          </td>
+                          <td className={tstyles.tdcta}>
+                            <a className={tstyles.cta} href={dwebURL} target="_blank">
+                              {dwebURL}
                             </a>
                           </td>
                           <td className={tstyles.td}>{U.bytesToSize(data.size)}</td>

--- a/pages/staging.tsx
+++ b/pages/staging.tsx
@@ -133,8 +133,8 @@ function StagingPage(props) {
                     </tr>
 
                     {bucket.contents.map((data, index) => {
-                      const estuaryRetrievalUrl = `${C.api.host}/gw/ipfs/${data.cid}`;
-                      const dwebRetrievalUrl = `https://dweb.link/ipfs/${data.cid}`;
+                      const estuaryRetrievalUrl = U.formatEstuaryRetrievalUrl(data.cid);
+                      const dwebRetrievalUrl = U.formatDwebRetrievalUrl(data.cid);
                       return (
                         <tr key={`${data.cid['/']}-${index}`} className={tstyles.tr}>
                           <td className={tstyles.td} style={{ fontSize: 12, fontFamily: 'Mono', opacity: 0.4 }}>

--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -4,6 +4,7 @@ import tstyles from '@pages/table.module.scss';
 import * as React from 'react';
 import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as C from '@common/constants';
 
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
@@ -76,8 +77,8 @@ function UploadCIDPage(props: any) {
             {U.isEmpty(state.cid) ? null : (
               <aside className={styles.formAside}>
                 Check your CID:{' '}
-                <a href={`https://dweb.link/ipfs/${state.cid}`} target="_blank">
-                  https://dweb.link/ipfs/{state.cid}
+                <a href={`${C.api.host}/gw/ipfs/${state.cid}`} target="_blank">
+                  {C.api.host}/gw/{state.cid}
                 </a>
                 .
               </aside>

--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -76,11 +76,19 @@ function UploadCIDPage(props: any) {
             />
             {U.isEmpty(state.cid) ? null : (
               <aside className={styles.formAside}>
-                Check your CID:{' '}
-                <a href={`${C.api.host}/gw/ipfs/${state.cid}`} target="_blank">
-                  {C.api.host}/gw/{state.cid}
-                </a>
-                .
+                Check your CID
+                <div>
+                  <H4>Estuary retrieval url</H4>
+                  <a href={`${C.api.host}/gw/ipfs/${state.cid}`} target="_blank">
+                    {C.api.host}/gw/{state.cid}
+                  </a>
+                </div>
+                <div>
+                  <H4>Dweb retrieval url</H4>
+                  <a href={`https://dweb.link/ipfs/${state.cid}`} target="_blank">
+                    https://dweb.link/ipfs/{state.cid}
+                  </a>
+                </div>
               </aside>
             )}
 

--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -1,23 +1,19 @@
 import styles from '@pages/app.module.scss';
-import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
-import * as C from '@common/constants';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import ActionRow from '@components/ActionRow';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import Block from '@components/Block';
-import Input from '@components/Input';
 import Button from '@components/Button';
+import Input from '@components/Input';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, H4, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -54,6 +50,8 @@ function UploadCIDPage(props: any) {
   });
 
   const sidebarElement = <AuthenticatedSidebar active="UPLOAD_CID" viewer={props.viewer} />;
+  const estuaryRetrievalUrl = !U.isEmpty(state.cid) ? U.formatEstuaryRetrievalUrl(state.cid) : null;
+  const dwebRetrievalUrl = !U.isEmpty(state.cid) ? U.formatDwebRetrievalUrl(state.cid) : null;
 
   return (
     <Page title="Estuary: Upload: CID" description="Use an existing IPFS CID to make storage deals." url={`${props.hostname}/upload-cid`}>
@@ -79,14 +77,14 @@ function UploadCIDPage(props: any) {
                 Check your CID
                 <div>
                   <H4>Estuary retrieval url</H4>
-                  <a href={`${C.api.host}/gw/ipfs/${state.cid}`} target="_blank">
-                    {C.api.host}/gw/{state.cid}
+                  <a href={estuaryRetrievalUrl} target="_blank">
+                    {estuaryRetrievalUrl}
                   </a>
                 </div>
                 <div>
                   <H4>Dweb retrieval url</H4>
-                  <a href={`https://dweb.link/ipfs/${state.cid}`} target="_blank">
-                    https://dweb.link/ipfs/{state.cid}
+                  <a href={dwebRetrievalUrl} target="_blank">
+                    {dwebRetrievalUrl}
                   </a>
                 </div>
               </aside>

--- a/pages/verify-cid.tsx
+++ b/pages/verify-cid.tsx
@@ -199,9 +199,14 @@ function VerifyCIDPage(props: any) {
             <React.Fragment>
               {statusElement}
               <StatRow title="CID">{state.data.content.cid}</StatRow>
-              <StatRow title="Retrieval URL">
+              <StatRow title="Estuary retrieval url">
                 <a href={`${C.api.host}/gw/ipfs/${state.data.content.cid}`} target="_blank">
                   ${C.api.host}/gw/ipfs/{state.data.content.cid}
+                </a>
+              </StatRow>
+              <StatRow title="Dweb retrieval url">
+                <a href={`https://dweb.link/ipfs/${state.data.content.cid}`} target="_blank">
+                  https://dweb.link/ipfs/{state.data.content.cid}
                 </a>
               </StatRow>
               <StatRow title="Estuary Node ID">{state.data.content.id}</StatRow>
@@ -215,9 +220,14 @@ function VerifyCIDPage(props: any) {
             <React.Fragment>
               {statusElement}
 
-              <StatRow title="Retrieval URL">
+              <StatRow title="Estuary retrieval url">
                 <a href={`${C.api.host}/gw/ipfs/${state.cid.trim()}`} target="_blank">
                   ${C.api.host}/gw/ipfs/{state.cid.trim()}
+                </a>
+              </StatRow>
+              <StatRow title="Dweb retrieval url">
+                <a href={`https://dweb.link/ipfs/${state.data.content.cid}`} target="_blank">
+                  https://dweb.link/ipfs/{state.data.content.cid}
                 </a>
               </StatRow>
             </React.Fragment>

--- a/pages/verify-cid.tsx
+++ b/pages/verify-cid.tsx
@@ -3,14 +3,10 @@ import S from '@pages/index.module.scss';
 import * as React from 'react';
 import * as U from '@common/utilities';
 import * as R from '@common/requests';
-import * as C from '@common/constants';
 
 import Page from '@components/Page';
 import Navigation from '@components/Navigation';
-import Card from '@components/Card';
 import Button from '@components/Button';
-import FeatureRow from '@components/FeatureRow';
-import MarketingCube from '@components/MarketingCube';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 import Input from '@components/Input';
 import StatRow from '@components/StatRow';
@@ -174,6 +170,10 @@ function VerifyCIDPage(props: any) {
     );
   }
 
+  const cid = state.data && state.data.content ? state.data.content.id : state.cid;
+  const estuaryRetrievalUrl = U.formatEstuaryRetrievalUrl(cid);
+  const dwebRetrievalUrl = U.formatDwebRetrievalUrl(cid);
+
   return (
     <Page title="Estuary: Verify CID" description={description} url={props.hostname}>
       <Navigation active="INDEX" isAuthenticated={props.viewer} />
@@ -200,13 +200,13 @@ function VerifyCIDPage(props: any) {
               {statusElement}
               <StatRow title="CID">{state.data.content.cid}</StatRow>
               <StatRow title="Estuary retrieval url">
-                <a href={`${C.api.host}/gw/ipfs/${state.data.content.cid}`} target="_blank">
-                  ${C.api.host}/gw/ipfs/{state.data.content.cid}
+                <a href={estuaryRetrievalUrl} target="_blank">
+                  {estuaryRetrievalUrl}
                 </a>
               </StatRow>
               <StatRow title="Dweb retrieval url">
-                <a href={`https://dweb.link/ipfs/${state.data.content.cid}`} target="_blank">
-                  https://dweb.link/ipfs/{state.data.content.cid}
+                <a href={dwebRetrievalUrl} target="_blank">
+                  {dwebRetrievalUrl}
                 </a>
               </StatRow>
               <StatRow title="Estuary Node ID">{state.data.content.id}</StatRow>
@@ -221,13 +221,13 @@ function VerifyCIDPage(props: any) {
               {statusElement}
 
               <StatRow title="Estuary retrieval url">
-                <a href={`${C.api.host}/gw/ipfs/${state.cid.trim()}`} target="_blank">
-                  ${C.api.host}/gw/ipfs/{state.cid.trim()}
+                <a href={estuaryRetrievalUrl} target="_blank">
+                  {estuaryRetrievalUrl}
                 </a>
               </StatRow>
               <StatRow title="Dweb retrieval url">
-                <a href={`https://dweb.link/ipfs/${state.data.content.cid}`} target="_blank">
-                  https://dweb.link/ipfs/{state.data.content.cid}
+                <a href={dwebRetrievalUrl} target="_blank">
+                  {dwebRetrievalUrl}
                 </a>
               </StatRow>
             </React.Fragment>

--- a/pages/verify-cid.tsx
+++ b/pages/verify-cid.tsx
@@ -3,6 +3,7 @@ import S from '@pages/index.module.scss';
 import * as React from 'react';
 import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as C from '@common/constants';
 
 import Page from '@components/Page';
 import Navigation from '@components/Navigation';
@@ -199,8 +200,8 @@ function VerifyCIDPage(props: any) {
               {statusElement}
               <StatRow title="CID">{state.data.content.cid}</StatRow>
               <StatRow title="Retrieval URL">
-                <a href={`https://dweb.link/ipfs/${state.data.content.cid}`} target="_blank">
-                  https://dweb.link/ipfs/{state.data.content.cid}
+                <a href={`${C.api.host}/gw/ipfs/${state.data.content.cid}`} target="_blank">
+                  ${C.api.host}/gw/ipfs/{state.data.content.cid}
                 </a>
               </StatRow>
               <StatRow title="Estuary Node ID">{state.data.content.id}</StatRow>
@@ -215,8 +216,8 @@ function VerifyCIDPage(props: any) {
               {statusElement}
 
               <StatRow title="Retrieval URL">
-                <a href={`https://dweb.link/ipfs/${state.cid.trim()}`} target="_blank">
-                  https://dweb.link/ipfs/{state.cid.trim()}
+                <a href={`${C.api.host}/gw/ipfs/${state.cid.trim()}`} target="_blank">
+                  ${C.api.host}/gw/ipfs/{state.cid.trim()}
                 </a>
               </StatRow>
             </React.Fragment>
@@ -253,7 +254,8 @@ function VerifyCIDPage(props: any) {
                         dealId={d.dealId}
                         cid={state.data.content.cid}
                         aggregatedIn={state.data.aggregatedIn?.cid}
-                        selector={state.data.selector} />
+                        selector={state.data.selector}
+                      />
                     </StatRow>
                   </div>
                 );
@@ -274,7 +276,7 @@ function VerifyCIDPage(props: any) {
 
       <div className={S.stats}>
         <div className={S.sc}>
-          <div className={S.scn}>{state.totalFilesStored ? state.totalFilesStored.toLocaleString() : "0"}</div>
+          <div className={S.scn}>{state.totalFilesStored ? state.totalFilesStored.toLocaleString() : '0'}</div>
           <div className={S.scl}>Total files</div>
         </div>
         <div className={S.sc}>


### PR DESCRIPTION
~Replaces any link that is intended to point to estuary-hosted content with the estuary gw instead of dweb.~ **Shows both gateway links throughout the UI, labeled as "Estuary retrieval url" and "Dweb retrieval url".** The estuary gw defers to dweb if the cid is not actively pinned by estuary or has been offloaded, so it is safe to point to the estuary gw as long as estuary API nodes are up. Dweb is still provided as a back up option until we decide to only show the estuary url. 

Note: For pinned directory nodes, users will get a much faster response on average through the estuary url but a much less dressed-up gateway UI, until we update our gateway rendering. 
- https://api.estuary.tech/gw/ipfs/bafybeidj7c2e3daplalccukbps4eze7473gyshspev76xi4sjfmfkuaofe/
- https://dweb.link/ipfs/bafybeidj7c2e3daplalccukbps4eze7473gyshspev76xi4sjfmfkuaofe

---
<img width="1512" alt="Screen Shot 2022-11-10 at 12 39 16 PM" src="https://user-images.githubusercontent.com/2850013/201167432-4a3d2f78-946e-46d3-b041-3a879653f862.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/2850013/201170499-cfecb986-296d-4ebd-905b-9cec3e211084.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/2850013/201167646-cbbce43a-284e-4d6e-bc71-0e924c8871e0.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/2850013/201167816-24e1266e-2b9d-4c82-9a53-d23ede8d6466.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/2850013/201167942-bc24f9ae-4c38-4927-a608-e9d711b85b9d.png">

