### PR TITLE
fix gateway url on verify-cid page

### DIFF
--- a/pages/verify-cid.tsx
+++ b/pages/verify-cid.tsx
@@ -170,7 +170,7 @@ function VerifyCIDPage(props: any) {
     );
   }
 
-  const cid = state.data && state.data.content ? state.data.content.id : state.cid;
+  const cid = state.data && state.data.content ? state.data.content.cid : state.cid;
   const estuaryRetrievalUrl = U.formatEstuaryRetrievalUrl(cid);
   const dwebRetrievalUrl = U.formatDwebRetrievalUrl(cid);
 


### PR DESCRIPTION
The verify page shows content ID instead of CID

before
<img width="763" alt="Screenshot 2022-11-21 at 15 28 31" src="https://user-images.githubusercontent.com/13554411/203079988-43022376-dcb9-48ee-a7d8-ee1f326e18e8.png">
after
<img width="810" alt="Screenshot 2022-11-21 at 15 26 38" src="https://user-images.githubusercontent.com/13554411/203080038-d7e1dff5-cd69-4062-a3b6-7e6ad3a97090.png">
