### PR TITLE
fix: increase column width

### DIFF
--- a/pages/errors/[id].tsx
+++ b/pages/errors/[id].tsx
@@ -62,7 +62,7 @@ function DealErrorPage(props: any) {
               <th className={tstyles.th} style={{ width: 120 }}>
                 provider
               </th>
-              <th className={tstyles.th} style={{ width: 120 }}>
+              <th className={tstyles.th} style={{ width: 140 }}>
                 deal uuid
               </th>
               <th className={tstyles.th} style={{ width: 120 }}>

--- a/pages/providers/errors/[id].tsx
+++ b/pages/providers/errors/[id].tsx
@@ -53,7 +53,7 @@ function MinerErrorPage(props: any) {
               <th className={tstyles.th} style={{ width: 104 }}>
                 Provider
               </th>
-              <th className={tstyles.th} style={{ width: 104 }}>
+              <th className={tstyles.th} style={{ width: 140 }}>
                 Deal UUID
               </th>
               <th className={tstyles.th} style={{ width: 96 }}>
@@ -71,7 +71,7 @@ function MinerErrorPage(props: any) {
                         {log.miner}
                       </a>
                     </td>
-                    <td className={tstyles.td}>{log.deal_uuid}</td>
+                    <td className={tstyles.td}>4658ab8f-026c-4249-b3ad-eac2104ae84b{log.deal_uuid}</td>
                     <td className={tstyles.td}>{log.phase}</td>
                     <td className={tstyles.td}>
                       <strong>[{log.minerVersion}]</strong> {log.message}

--- a/pages/providers/errors/[id].tsx
+++ b/pages/providers/errors/[id].tsx
@@ -71,7 +71,7 @@ function MinerErrorPage(props: any) {
                         {log.miner}
                       </a>
                     </td>
-                    <td className={tstyles.td}>4658ab8f-026c-4249-b3ad-eac2104ae84b{log.deal_uuid}</td>
+                    <td className={tstyles.td}>{log.deal_uuid}</td>
                     <td className={tstyles.td}>{log.phase}</td>
                     <td className={tstyles.td}>
                       <strong>[{log.minerVersion}]</strong> {log.message}


### PR DESCRIPTION
Increased width of the Deal UUID column so uuids don't get truncated. 

Before, it looked like this:
![image](https://user-images.githubusercontent.com/12418265/203125088-daf70806-e450-4301-a337-8ff7f196dab0.png)


Now it looks like this: 
<img width="821" alt="Screenshot 2022-11-21 at 9 47 05 AM" src="https://user-images.githubusercontent.com/12418265/203124937-7b35d8bc-5148-4c28-aa4a-dfc41dd7dc40.png">
