### PR TITLE
Render local id instead of index in staging table

### DIFF
--- a/pages/staging.tsx
+++ b/pages/staging.tsx
@@ -104,7 +104,7 @@ function StagingPage(props) {
                 <table className={tstyles.table}>
                   <tbody className={tstyles.tbody}>
                     <tr className={tstyles.tr}>
-                      <th className={tstyles.th} style={{ width: '80px' }}>
+                      <th className={tstyles.th} style={{ width: '88px' }}>
                         Local ID
                       </th>
 
@@ -127,7 +127,7 @@ function StagingPage(props) {
                       return (
                         <tr key={`${data.cid['/']}-${data.id}`} className={tstyles.tr}>
                           <td className={tstyles.td} style={{ fontSize: 12, fontFamily: 'Mono', opacity: 0.4 }}>
-                            {String(data.id).padStart(7, '0')}
+                            {String(data.id).padStart(9, '0')}
                           </td>
                           <td className={tstyles.td}>{data.name}</td>
                           <td className={tstyles.tdcta}>


### PR DESCRIPTION
Rendering by index is confusing if you are deleting pins by local id. Since we display the item count in the bucket metadata now, rendering each index also doesn't add much info.

Ran into this confusion while working on https://github.com/application-research/estuary/pull/555

![image](https://user-images.githubusercontent.com/2850013/203147924-7aabc5d7-114f-4352-b469-1e0def2be241.png)