### PR TITLE
Also show label dialog for permanent keys

### DIFF
--- a/components/CreateKeyModalBody.tsx
+++ b/components/CreateKeyModalBody.tsx
@@ -41,9 +41,8 @@ function CreateKeyModalBody(props: any) {
     return (
       <div className={styles.group} style={{ paddingTop: '16px' }}>
         <P style={{ maxWidth: '620px' }}>
-          Copy and save the following API key corresponding to your "<b>{state.label}</b>" label.
-          {/* once db is omitting token, add language: "For security purposes, we do not store this API key. If it is lost or compromised, please revoke
-          and create a new key." */}
+          Copy and save the following API key corresponding to your "<b>{state.label}</b>" label. For security purposes, we do not store this API key. If it is lost or compromised,
+          please revoke it and create a new key.
         </P>
         <H4 style={{ marginTop: '16px', width: '488px', display: 'inline-block' }}>{state.token}</H4>
         <CopyButton content={state.token} />

--- a/components/CreateKeyModalBody.tsx
+++ b/components/CreateKeyModalBody.tsx
@@ -1,19 +1,23 @@
 import styles from '@pages/app.module.scss';
 
-import * as React from 'react';
 import * as R from '@common/requests';
-import Button from './Button';
-import Input from './Input';
 import { useState } from 'react';
-import { H4, P } from './Typography';
+import Button from './Button';
 import CopyButton from './CopyButton';
+import Input from './Input';
+import { H4, P } from './Typography';
 
 function CreateKeyModalBody(props: any) {
   const [state, setState] = useState({ token: null, label: null, loading: false, copied: false });
 
   const onSubmit = async () => {
     setState({ ...state, loading: true });
-    const authToken = await R.post(`/user/api-keys?label=${state.label}`, {}, props.api);
+    var authToken;
+    if (props.expiry == false) {
+      authToken = await R.post(`/user/api-keys?expiry=false&label=${state.label}`, { expiry: false }, props.api);
+    } else {
+      authToken = await R.post(`/user/api-keys?label=${state.label}`, {}, props.api);
+    }
     setState({ ...state, token: authToken.token, loading: false });
   };
   if (!state.token) {

--- a/pages/api-admin.tsx
+++ b/pages/api-admin.tsx
@@ -1,26 +1,23 @@
 import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as C from '@common/constants';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Cookie from 'js-cookie';
-import ProgressCard from '@components/ProgressCard';
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import PageHeader from '@components/PageHeader';
 import Button from '@components/Button';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import PageHeader from '@components/PageHeader';
+import Cookie from 'js-cookie';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
-import Modal from '@root/components/Modal';
-import Input from '@root/components/Input';
-import CreateKeyModalBody from '@root/components/CreateKeyModalBody';
+import { H2, P } from '@components/Typography';
 import CopyButton from '@root/components/CopyButton';
+import CreateKeyModalBody from '@root/components/CreateKeyModalBody';
+import Modal from '@root/components/Modal';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -46,6 +43,7 @@ function APIPage(props: any) {
   console.log(viewerToken);
   const [state, setState] = React.useState({ keys: [], loading: false });
   const [showCreateKeyModal, setShowCreateKeyModal] = React.useState(false);
+  const [showCreatePermanentKeyModal, setShowCreatePermanentKeyModal] = React.useState(false);
 
   React.useEffect(() => {
     const run = async () => {
@@ -58,7 +56,7 @@ function APIPage(props: any) {
     };
 
     run();
-  }, [showCreateKeyModal]);
+  }, [showCreateKeyModal, showCreatePermanentKeyModal]);
 
   const sidebarElement = <AuthenticatedSidebar active="API" viewer={props.viewer} />;
 
@@ -101,19 +99,23 @@ function APIPage(props: any) {
                 color: 'var(--main-button-text-secondary)',
               }}
               loading={state.loading ? state.loading : undefined}
-              onClick={async () => {
-                setState({ ...state, loading: true });
-                const request = await R.post(`/user/api-keys?expiry=false`, { expiry: false }, props.api);
-
-                const keys = await R.get('/user/api-keys', props.api);
-                if (keys && !keys.error) {
-                  setState({ ...state, loading: false, keys });
-                  return;
-                }
+              onClick={() => {
+                setShowCreatePermanentKeyModal(true);
               }}
             >
               Create permanent key
             </Button>
+            {showCreatePermanentKeyModal && (
+              <Modal
+                title="Create Permanent Key"
+                onClose={() => {
+                  setShowCreatePermanentKeyModal(false);
+                }}
+                show={showCreatePermanentKeyModal}
+              >
+                <CreateKeyModalBody expiry={false} />
+              </Modal>
+            )}
             <Button
               style={{
                 marginBottom: 24,


### PR DESCRIPTION
Fixes perm keys being auto-created with no label and never showing the actual key in the UI. Now, the behavior matches the flow for regular keys.

Also adds in the language that we don't store api keys.