### PR TITLE
fix: use metrics api on ecosystem dev page for stats

### DIFF
--- a/pages/comparisons-web3.tsx
+++ b/pages/comparisons-web3.tsx
@@ -13,7 +13,7 @@ import MarketingCube from '@components/MarketingCube';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 import ComparisonWeb3 from '@components/ComparisonWeb3';
 import Chart from '@components/Chart';
-
+import * as C from '@common/constants';
 import { H1, H2, H3, H4, P } from '@components/Typography';
 import { MarketingUpload, MarketingProgress, MarketingGraph } from '@components/Marketing';
 
@@ -55,7 +55,7 @@ function ComparisonsWeb3Page(props: any) {
   React.useEffect(() => {
     const run = async () => {
       const miners = await R.get('/public/miners', props.api);
-      const stats = await R.get('/public/stats', props.api);
+      const stats = await R.get('/api/v1/stats/info', C.api.metricsHost);
 
       if ((miners && miners.error) || (stats && stats.error)) {
         return setState({ ...state, miners: [], totalStorage: 0, totalFilesStored: 0 });

--- a/pages/comparisons.tsx
+++ b/pages/comparisons.tsx
@@ -13,7 +13,7 @@ import MarketingCube from '@components/MarketingCube';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 import Comparison from '@components/Comparison';
 import Chart from '@components/Chart';
-
+import * as C from '@common/constants';
 import { H1, H2, H3, H4, P } from '@components/Typography';
 import { MarketingUpload, MarketingProgress, MarketingGraph } from '@components/Marketing';
 
@@ -55,7 +55,7 @@ function ComparisonPage(props: any) {
   React.useEffect(() => {
     const run = async () => {
       const miners = await R.get('/public/miners', props.api);
-      const stats = await R.get('/public/stats', props.api);
+      const stats = await R.get('/api/v1/stats/info', C.api.metricsHost);
 
       if ((miners && miners.error) || (stats && stats.error)) {
         return setState({ ...state, miners: [], totalStorage: 0, totalFilesStored: 0 });

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -113,7 +113,7 @@ function EcosystemPage(props: any) {
   React.useEffect(() => {
     const run = async () => {
       const miners = await R.get('/public/miners', props.api);
-      const stats = await R.get('/public/stats', props.api);
+      const stats = await R.get('/api/v1/stats/info', C.api.metricsHost);
       const environment = await R.post('/api/v1/environment/equinix/list/usages', staticEnvironmentPayload, C.api.metricsHost);
 
       if ((miners && miners.error) || (stats && stats.error)) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ import FeatureRow from '@components/FeatureRow';
 import MarketingCube from '@components/MarketingCube';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 import Chart from '@components/Chart';
-
+import * as C from '@common/constants';
 import { H1, H2, H3, H4, P } from '@components/Typography';
 import { MarketingUpload, MarketingProgress, MarketingGraph } from '@components/Marketing';
 
@@ -47,7 +47,7 @@ function IndexPage(props: any) {
       let stats;
       try {
         miners = await R.get('/public/miners', props.api);
-        stats = await R.get('/public/stats', props.api);
+        stats = await R.get('/api/v1/stats/info', C.api.metricsHost);
       } catch (e) {}
 
       if ((miners && miners.error) || (stats && stats.error)) {

--- a/pages/verify-cid.tsx
+++ b/pages/verify-cid.tsx
@@ -12,7 +12,7 @@ import Input from '@components/Input';
 import StatRow from '@components/StatRow';
 import LoaderSpinner from '@components/LoaderSpinner';
 import RetrievalCommands from '@components/RetrievalCommands';
-
+import * as C from '@common/constants';
 import { H1, H2, H3, H4, P } from '@components/Typography';
 
 // NOTE(jim): test CIDs
@@ -91,7 +91,7 @@ function VerifyCIDPage(props: any) {
 
   React.useEffect(() => {
     const load = async () => {
-      const stats = await R.get('/public/stats', props.api);
+      const stats = await R.get('/api/v1/stats/info', C.api.metricsHost);
       const urlSearchParams = new URLSearchParams(window.location.search);
       const params = Object.fromEntries(urlSearchParams.entries());
 


### PR DESCRIPTION
# Changes

- use metrics api to get the stats on ecosystem dev page

# Verification

Metrics api uses the same data source but the endpoints (web services) are hosted on a different HA server using render.com

Here's the swagger endpoint
https://metrics-api.onrender.com/swagger/index.html#/Stats/get_stats_info


## Index page
![image](https://user-images.githubusercontent.com/4479171/204553721-7bd48622-abd9-4e29-ae90-8140abeda1d5.png)

## Verify page
![image](https://user-images.githubusercontent.com/4479171/204553583-05b987f9-8f5b-4f66-8576-becc31b1df1c.png)

## Comparison Page
![image](https://user-images.githubusercontent.com/4479171/204553653-2e71b2f3-a479-4027-8e6e-76f02b0fd90b.png)

# Ecosystem page
![image](https://user-images.githubusercontent.com/4479171/204553438-142c4eb9-c73c-41b7-ad60-6cf3ccc0d412.png)
