### PR TITLE
feat: use metrics api deal-on-chain endpoint

### DIFF
--- a/pages/comparisons-web3.tsx
+++ b/pages/comparisons-web3.tsx
@@ -69,7 +69,7 @@ function ComparisonsWeb3Page(props: any) {
 
   React.useEffect(() => {
     const load = async () => {
-      const data = await R.get('/public/metrics/deals-on-chain', props.api);
+      const data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost);
 
       let dealsAttempted = 0;
       let dealsAttemptedSet = [];

--- a/pages/comparisons.tsx
+++ b/pages/comparisons.tsx
@@ -69,7 +69,8 @@ function ComparisonPage(props: any) {
 
   React.useEffect(() => {
     const load = async () => {
-      const data = await R.get('/public/metrics/deals-on-chain', props.api);
+      //const data = await R.get('/public/metrics/deals-on-chain', props.api);
+      const data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost)
 
       let dealsAttempted = 0;
       let dealsAttemptedSet = [];

--- a/pages/comparisons.tsx
+++ b/pages/comparisons.tsx
@@ -69,7 +69,6 @@ function ComparisonPage(props: any) {
 
   React.useEffect(() => {
     const load = async () => {
-      //const data = await R.get('/public/metrics/deals-on-chain', props.api);
       const data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost)
 
       let dealsAttempted = 0;

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -127,7 +127,6 @@ function EcosystemPage(props: any) {
 
   React.useEffect(() => {
     const load = async () => {
-      //const data = await R.get('/public/metrics/deals-on-chain', props.api);
       const data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost)
 
       let dealsAttempted = 0;

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -127,7 +127,8 @@ function EcosystemPage(props: any) {
 
   React.useEffect(() => {
     const load = async () => {
-      const data = await R.get('/public/metrics/deals-on-chain', props.api);
+      //const data = await R.get('/public/metrics/deals-on-chain', props.api);
+      const data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost)
 
       let dealsAttempted = 0;
       let dealsAttemptedSet = [];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -64,7 +64,6 @@ function IndexPage(props: any) {
     async function load() {
       let data;
       try {
-        //data = await R.get('/public/metrics/deals-on-chain', props.api);
         data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost)
 
       } catch (e) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -64,7 +64,9 @@ function IndexPage(props: any) {
     async function load() {
       let data;
       try {
-        data = await R.get('/public/metrics/deals-on-chain', props.api);
+        //data = await R.get('/public/metrics/deals-on-chain', props.api);
+        data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost)
+
       } catch (e) {
         console.log(e);
         return null;


### PR DESCRIPTION
# Changes
- use stats/deal-metrics from metrics api to replace the /deals-on-chain endpoint

# Verification

## Ecosystem
![image](https://user-images.githubusercontent.com/4479171/204572024-fa322ba0-a01d-47fa-aada-9a811c763fd3.png)
