### PR TITLE
Remove files col + Show size and created at in files table

### DIFF
--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -30,7 +30,7 @@ const FilesTable = ({ files }) => {
             return data.filename;
           }
         },
-        width: '17%',
+        width: '15%',
         Filter: DefaultColumnFilter,
       },
 
@@ -45,7 +45,7 @@ const FilesTable = ({ files }) => {
             {value}
           </a>
         ),
-        width: '50%',
+        width: '55%',
         Filter: DefaultColumnFilter,
       },
       {
@@ -63,7 +63,7 @@ const FilesTable = ({ files }) => {
         accessor: (data) => {
           return U.toDate(data.createdAt);
         },
-        width: '25%',
+        width: '22%',
         Filter: DefaultColumnFilter,
       },
     ],

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -13,7 +13,7 @@ const FilesTable = ({ files }) => {
         accessor: (data) => String(data.id).padStart(9, '0'),
         Cell: ({ value }) => <span style={{ fontFamily: 'Mono', opacity: 0.4 }}>{value}</span>,
         disableFilters: true,
-        width: '10em',
+        width: '7.8em',
       },
 
       {
@@ -30,7 +30,7 @@ const FilesTable = ({ files }) => {
             return data.filename;
           }
         },
-        width: '20%',
+        width: '25%',
         Filter: DefaultColumnFilter,
       },
 
@@ -45,7 +45,7 @@ const FilesTable = ({ files }) => {
             {value}
           </a>
         ),
-        width: '45%',
+        width: '40%',
         Filter: DefaultColumnFilter,
       },
       {
@@ -54,7 +54,7 @@ const FilesTable = ({ files }) => {
         accessor: (data) => {
           return U.bytesToSize(data.size);
         },
-        width: '15%',
+        width: '7em',
         Filter: DefaultColumnFilter,
       },
       {
@@ -63,7 +63,7 @@ const FilesTable = ({ files }) => {
         accessor: (data) => {
           return U.toDate(data.createdAt);
         },
-        width: '20%',
+        width: '30%',
         Filter: DefaultColumnFilter,
       },
     ],

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -147,15 +147,13 @@ const FilesTable = ({ files }) => {
         <tbody className={tstyles.tbody} {...getTableBodyProps()}>
           {page.map((row) => {
             prepareRow(row);
-            if (row.values.Name != './') {
-              return (
-                <tr className={tstyles.tr} {...row.getRowProps([{ style: {} }])}>
-                  {row.cells.map((cell) => {
-                    return <td className={tstyles.td}>{cell.render('Cell')}</td>;
-                  })}
-                </tr>
-              );
-            }
+            return (
+              <tr className={tstyles.tr} {...row.getRowProps([{ style: {} }])}>
+                {row.cells.map((cell) => {
+                  return <td className={tstyles.td}>{cell.render('Cell')}</td>;
+                })}
+              </tr>
+            );
           })}
         </tbody>
       </table>

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -12,7 +12,7 @@ const FilesTable = ({ files }) => {
         accessor: (data) => String(data.id).padStart(9, '0'),
         Cell: ({ value }) => <div style={{ fontFamily: 'Mono', opacity: 0.4 }}>{value}</div>,
         disableFilters: true,
-        width: '20%',
+        width: '10%',
       },
 
       {
@@ -44,16 +44,8 @@ const FilesTable = ({ files }) => {
             {value}
           </a>
         ),
-        width: '35%',
+        width: '60%',
         Filter: DefaultColumnFilter,
-      },
-
-      {
-        id: 'Files',
-        Header: 'Files',
-        accessor: (data) => data.aggregatedFiles + 1,
-        disableFilters: true,
-        width: '15%',
       },
     ],
     [gateway]
@@ -95,15 +87,15 @@ const FilesTable = ({ files }) => {
   }
   return (
     <React.Fragment>
+      <div className={tstyles.gateway}>
+        <label>Gateway:</label>
+        <select className={tstyles.gatewayInput} value={gateway} onChange={(e) => setGateway(e.target.value)}>
+          <option value="https://api.estuary.tech/gw/ipfs/">Estuary.tech</option>
+          <option value="https://dweb.link/ipfs/">Dweb</option>
+          <option value="https://strn.pl/ipfs/">Saturn</option>
+        </select>
+      </div>
       <table className={tstyles.table} {...getTableProps()}>
-        <div className={tstyles.gateway}>
-          <label>Gateway:</label>
-          <select className={tstyles.gatewayInput} value={gateway} onChange={(e) => setGateway(e.target.value)}>
-            <option value="https://gateway.estuary.tech/gw/ipfs/">Estuary.tech</option>
-            <option value="https://dweb.link/ipfs/">Dweb</option>
-            <option value="https://strn.pl/ipfs/">Saturn</option>
-          </select>
-        </div>
         <thead>
           {headerGroups.map((headerGroup) => (
             <tr className={tstyles.tr} {...headerGroup.getHeaderGroupProps()}>

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -155,13 +155,15 @@ const FilesTable = ({ files }) => {
         <tbody className={tstyles.tbody} {...getTableBodyProps()}>
           {page.map((row) => {
             prepareRow(row);
-            return (
-              <tr className={tstyles.tr} {...row.getRowProps([{ style: {} }])}>
-                {row.cells.map((cell) => {
-                  return <td className={tstyles.td}>{cell.render('Cell')}</td>;
-                })}
-              </tr>
-            );
+            if (row.values.Name != './') {
+              return (
+                <tr className={tstyles.tr} {...row.getRowProps([{ style: {} }])}>
+                  {row.cells.map((cell) => {
+                    return <td className={tstyles.td}>{cell.render('Cell')}</td>;
+                  })}
+                </tr>
+              );
+            }
           })}
         </tbody>
       </table>

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -1,3 +1,4 @@
+import * as U from '@common/utilities';
 import tstyles from '@pages/files-table.module.scss';
 import React, { useMemo, useState } from 'react';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
@@ -10,7 +11,7 @@ const FilesTable = ({ files }) => {
         id: 'Local Id',
         Header: 'Local id',
         accessor: (data) => String(data.id).padStart(9, '0'),
-        Cell: ({ value }) => <div style={{ fontFamily: 'Mono', opacity: 0.4 }}>{value}</div>,
+        Cell: ({ value }) => <span style={{ fontFamily: 'Mono', opacity: 0.4 }}>{value}</span>,
         disableFilters: true,
         width: '10%',
       },
@@ -29,7 +30,7 @@ const FilesTable = ({ files }) => {
             return data.filename;
           }
         },
-        width: '30%',
+        width: '17%',
         Filter: DefaultColumnFilter,
       },
 
@@ -44,7 +45,25 @@ const FilesTable = ({ files }) => {
             {value}
           </a>
         ),
-        width: '60%',
+        width: '50%',
+        Filter: DefaultColumnFilter,
+      },
+      {
+        id: 'Size',
+        Header: 'Size',
+        accessor: (data) => {
+          return U.bytesToSize(data.size);
+        },
+        width: '8%',
+        Filter: DefaultColumnFilter,
+      },
+      {
+        id: 'Created At',
+        Header: 'Created At',
+        accessor: (data) => {
+          return U.toDate(data.createdAt);
+        },
+        width: '25%',
         Filter: DefaultColumnFilter,
       },
     ],

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -13,7 +13,7 @@ const FilesTable = ({ files }) => {
         accessor: (data) => String(data.id).padStart(9, '0'),
         Cell: ({ value }) => <span style={{ fontFamily: 'Mono', opacity: 0.4 }}>{value}</span>,
         disableFilters: true,
-        width: '10%',
+        width: '10em',
       },
 
       {
@@ -30,7 +30,7 @@ const FilesTable = ({ files }) => {
             return data.filename;
           }
         },
-        width: '15%',
+        width: '20%',
         Filter: DefaultColumnFilter,
       },
 
@@ -45,7 +45,7 @@ const FilesTable = ({ files }) => {
             {value}
           </a>
         ),
-        width: '55%',
+        width: '45%',
         Filter: DefaultColumnFilter,
       },
       {
@@ -54,7 +54,7 @@ const FilesTable = ({ files }) => {
         accessor: (data) => {
           return U.bytesToSize(data.size);
         },
-        width: '8%',
+        width: '15%',
         Filter: DefaultColumnFilter,
       },
       {
@@ -63,7 +63,7 @@ const FilesTable = ({ files }) => {
         accessor: (data) => {
           return U.toDate(data.createdAt);
         },
-        width: '22%',
+        width: '20%',
         Filter: DefaultColumnFilter,
       },
     ],

--- a/components/StagingZoneReadinessTable.tsx
+++ b/components/StagingZoneReadinessTable.tsx
@@ -1,0 +1,26 @@
+import styles from '@pages/app.module.scss';
+import tstyles from '@pages/table.module.scss';
+
+import * as U from '@common/utilities';
+
+function StagingZoneReadinessTable(props: any) {
+  if (props.readiness) {
+    return (
+      <table className={tstyles.table}>
+        <tbody className={tstyles.tbody}>
+          <tr className={tstyles.tr}>
+            <th className={tstyles.th}>Ready? (updates every 5 minutes)</th>
+            <th className={tstyles.th}>Readiness Reason</th>
+          </tr>
+          <tr className={tstyles.tr}>
+            <td className={tstyles.td}>{U.formatBoolean(props.readiness.isReady)}</td>
+            <td className={U.classNames(tstyles.td, styles.multiline)}>{props.readiness.readinessReason}</td>
+          </tr>
+        </tbody>
+      </table>
+    );
+  }
+  return null;
+}
+
+export default StagingZoneReadinessTable;

--- a/pages/files-table.module.scss
+++ b/pages/files-table.module.scss
@@ -80,9 +80,12 @@
 }
 
 .td {
-  padding: 8px 8px 8px 14px;
+  padding: 1em;
   overflow: hidden;
   text-overflow: ellipsis;
+  @media (max-width: 960px) {
+    padding: 0.5em;
+  }
 }
 
 .tdcta {
@@ -95,7 +98,6 @@
 
 .cta {
   display: block;
-  padding: 8px 8px 8px 14px;
   transition: 200ms ease all;
   color: var(--main-background-table-text-color);
   text-decoration: none;

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,23 +1,19 @@
 import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import ProgressCard from '@components/ProgressCard';
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
+import ActionRow from '@components/ActionRow';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import PageHeader from '@components/PageHeader';
 import Button from '@components/Button';
-import ActionRow from '@components/ActionRow';
-import AlertPanel from '@components/AlertPanel';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import PageHeader from '@components/PageHeader';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, P } from '@components/Typography';
 import FilesTable from '@root/components/FilesTable';
 
 const INCREMENT = 1000;
@@ -127,12 +123,10 @@ function HomePage(props: any) {
             </table>
           </div>
         ) : null}
-        
+
         <div className={styles.group}>
-          {state.files && state.files.length ? (
-            <FilesTable files={state.files}/>
-          ) : null}
-          
+          {state.files && state.files.length ? <FilesTable files={state.files} /> : null}
+
           {state.files && state.offset + state.limit === state.files.length ? (
             <ActionRow style={{ paddingLeft: 16, paddingRight: 16 }} onClick={() => getNext(state, setState, props.api)}>
               ➝ Next {INCREMENT}


### PR DESCRIPTION
1. https://github.com/application-research/estuary/pull/631 removed aggregate rows from /content/stats, so the Files column becomes irrelevant and is removed in this PR
2. Size and createdAt were added to the /content/stats response data, and is rendered in this PR
3. some col width tuning

To be released after estuary 0.2.1.

before:
![image](https://user-images.githubusercontent.com/2850013/204901701-07327b6a-7171-445d-b5df-5aa374e49362.png)

after:
![image](https://user-images.githubusercontent.com/2850013/204920385-9877ec59-13ed-4737-87fc-efeb9af56812.png)