### PR TITLE
Prefix NEXT_PUBLIC_ on ESTUARY_API and ESTUARY_METRICS_API

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -42,8 +42,9 @@ export const regex = {
 
 
 function getMetricsHost(): string {
-  if (process.env.ESTUARY_METRICS_API) {
-    return process.env.ESTUARY_METRICS_API;
+  console.log(process.env);
+  if (process.env.NEXT_PUBLIC_ESTUARY_METRICS_API) {
+    return process.env.NEXT_PUBLIC_ESTUARY_METRICS_API;
   }
 
   switch (process.env.NODE_ENV) {
@@ -54,8 +55,8 @@ function getMetricsHost(): string {
   }
 }
 function getAPIHost(): string {
-  if (process.env.ESTUARY_API) {
-    return process.env.ESTUARY_API;
+  if (process.env.NEXT_PUBLIC_ESTUARY_API) {
+    return process.env.NEXT_PUBLIC_ESTUARY_API;
   }
 
   switch (process.env.NODE_ENV) {

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -42,7 +42,6 @@ export const regex = {
 
 
 function getMetricsHost(): string {
-  console.log(process.env);
   if (process.env.NEXT_PUBLIC_ESTUARY_METRICS_API) {
     return process.env.NEXT_PUBLIC_ESTUARY_METRICS_API;
   }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "node": "14.x"
   },
   "scripts": {
-    "dev": "ESTUARY_API=http://localhost:3004 next dev -p 4444",
-    "dev-docker": "ESTUARY_API=${ESTUARY_API:-http://localhost:3004} next dev -p 4444",
-    "dev-production": "ESTUARY_API=https://api.estuary.tech next dev -p 4444",
+    "dev": "NEXT_PUBLIC_ESTUARY_API=http://localhost:3004 next dev -p 4444",
+    "dev-docker": "NEXT_PUBLIC_ESTUARY_API=${ESTUARY_API:-http://localhost:3004} next dev -p 4444",
+    "dev-production": "NEXT_PUBLIC_ESTUARY_API=https://api.estuary.tech NEXT_PUBLIC_ESTUARY_METRICS_API=https://metrics-api.estuary.tech next dev -p 4444",
     "build": "next build",
     "check-types": "tsc --noemit",
     "start": "NODE_ENV=production next start",

--- a/pages/_.tsx
+++ b/pages/_.tsx
@@ -1,13 +1,9 @@
-import styles from '@pages/app.module.scss';
-
-import * as React from 'react';
 import * as U from '@common/utilities';
 
-import ProgressCard from '@components/ProgressCard';
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -22,7 +18,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/admin/.template.tsx
+++ b/pages/admin/.template.tsx
@@ -1,18 +1,13 @@
-import styles from '@pages/app.module.scss';
-
-import * as React from 'react';
 import * as U from '@common/utilities';
-import * as R from '@common/requests';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import Block from '@components/Block';
 
-import { H1, H2, P } from '@components/Typography';
+import { H2, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -36,7 +31,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -1,17 +1,13 @@
-import styles from '@pages/app.module.scss';
-
-import * as React from 'react';
-import * as U from '@common/utilities';
-import * as C from '@common/constants';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Cookies from 'js-cookie';
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
 import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -35,7 +31,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/admin/balance.tsx
+++ b/pages/admin/balance.tsx
@@ -1,20 +1,19 @@
 import styles from '@pages/app.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
 import Block from '@components/Block';
-import Input from '@components/Input';
 import Button from '@components/Button';
+import Input from '@components/Input';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, H3, H4, P } from '@components/Typography';
 
 const sendEscrow = async (state, setState, host) => {
   setState({ ...state, loading: true });
@@ -79,7 +78,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/admin/content.tsx
+++ b/pages/admin/content.tsx
@@ -35,7 +35,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/admin/impersonate.tsx
+++ b/pages/admin/impersonate.tsx
@@ -1,23 +1,19 @@
 import styles from '@pages/app.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as C from '@common/constants';
-import * as R from '@common/requests';
-import * as Crypto from '@common/crypto';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Cookies from 'js-cookie';
-import ProgressCard from '@components/ProgressCard';
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import Input from '@components/Input';
 import Button from '@components/Button';
+import Input from '@components/Input';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
+import Cookies from 'js-cookie';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, H3, H4, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -41,7 +37,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/admin/invites.tsx
+++ b/pages/admin/invites.tsx
@@ -1,22 +1,19 @@
 import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import PageHeader from '@components/PageHeader';
-import Block from '@components/Block';
-import Input from '@components/Input';
 import Button from '@components/Button';
+import Input from '@components/Input';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import PageHeader from '@components/PageHeader';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, H4, P } from '@components/Typography';
 import { v4 as uuidv4 } from 'uuid';
 
 export async function getServerSideProps(context) {
@@ -41,7 +38,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 
@@ -136,7 +133,10 @@ function AdminInvitesPage(props: any) {
               </tr>
               {state.invites && state.invites.length
                 ? state.invites.map((data, index) => {
-                    const inviteLink = window.location.hostname === 'localhost' ?  `http://${window.location.host}/sign-up?invite=${data.code}` : `https://${window.location.hostname}/sign-up?invite=${data.code}`;
+                    const inviteLink =
+                      window.location.hostname === 'localhost'
+                        ? `http://${window.location.host}/sign-up?invite=${data.code}`
+                        : `https://${window.location.hostname}/sign-up?invite=${data.code}`;
                     return (
                       <tr key={data.code} className={tstyles.tr} style={{ opacity: !U.isEmpty(data.claimedBy) ? 0.2 : 1 }}>
                         <td className={tstyles.td}>

--- a/pages/admin/providers.tsx
+++ b/pages/admin/providers.tsx
@@ -1,21 +1,19 @@
 import styles from '@pages/app.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import PageHeader from '@components/PageHeader';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import Block from '@components/Block';
-import Input from '@components/Input';
 import Button from '@components/Button';
+import Input from '@components/Input';
 import MinerTable from '@components/MinerTable';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import PageHeader from '@components/PageHeader';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, H4, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -39,7 +37,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/admin/shuttle.tsx
+++ b/pages/admin/shuttle.tsx
@@ -1,22 +1,18 @@
 import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import PageHeader from '@components/PageHeader';
-import Block from '@components/Block';
-import Input from '@components/Input';
 import Button from '@components/Button';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import PageHeader from '@components/PageHeader';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, H3, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -40,7 +36,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/admin/stats.tsx
+++ b/pages/admin/stats.tsx
@@ -1,19 +1,18 @@
 import styles from '@pages/app.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
 import Block from '@components/Block';
 import Button from '@components/Button';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -37,7 +36,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,19 +1,17 @@
 import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 import PageHeader from '@components/PageHeader';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -37,7 +35,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/api-admin.tsx
+++ b/pages/api-admin.tsx
@@ -32,7 +32,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/comparisons-web3.tsx
+++ b/pages/comparisons-web3.tsx
@@ -1,27 +1,23 @@
 import S from '@pages/index.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Page from '@components/Page';
-import Navigation from '@components/Navigation';
-import Card from '@components/Card';
-import Button from '@components/Button';
-import FeatureRow from '@components/FeatureRow';
-import MarketingCube from '@components/MarketingCube';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import ComparisonWeb3 from '@components/ComparisonWeb3';
-import Chart from '@components/Chart';
 import * as C from '@common/constants';
-import { H1, H2, H3, H4, P } from '@components/Typography';
-import { MarketingUpload, MarketingProgress, MarketingGraph } from '@components/Marketing';
+import Button from '@components/Button';
+import Chart from '@components/Chart';
+import ComparisonWeb3 from '@components/ComparisonWeb3';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
+import { H1, H2, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/comparisons.tsx
+++ b/pages/comparisons.tsx
@@ -1,27 +1,23 @@
 import S from '@pages/index.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Page from '@components/Page';
-import Navigation from '@components/Navigation';
-import Card from '@components/Card';
-import Button from '@components/Button';
-import FeatureRow from '@components/FeatureRow';
-import MarketingCube from '@components/MarketingCube';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import Comparison from '@components/Comparison';
-import Chart from '@components/Chart';
 import * as C from '@common/constants';
-import { H1, H2, H3, H4, P } from '@components/Typography';
-import { MarketingUpload, MarketingProgress, MarketingGraph } from '@components/Marketing';
+import Button from '@components/Button';
+import Chart from '@components/Chart';
+import Comparison from '@components/Comparison';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
+import { H1, H2, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 
@@ -69,7 +65,7 @@ function ComparisonPage(props: any) {
 
   React.useEffect(() => {
     const load = async () => {
-      const data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost)
+      const data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost);
 
       let dealsAttempted = 0;
       let dealsAttemptedSet = [];

--- a/pages/content/[id].tsx
+++ b/pages/content/[id].tsx
@@ -1,14 +1,13 @@
-import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -23,7 +22,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, ...context.params, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, ...context.params, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/deals/[id].tsx
+++ b/pages/deals/[id].tsx
@@ -1,15 +1,13 @@
-import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
-import * as C from '@common/constants';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -24,7 +22,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, ...context.params, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, ...context.params, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/deals/debug.tsx
+++ b/pages/deals/debug.tsx
@@ -1,14 +1,13 @@
-import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -23,7 +22,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, ...context.params, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, ...context.params, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/deals/index.tsx
+++ b/pages/deals/index.tsx
@@ -1,23 +1,21 @@
 import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
-import * as C from '@common/constants';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import ProgressCard from '@components/ProgressCard';
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
-import LoaderSpinner from '@components/LoaderSpinner';
-import PageHeader from '@components/PageHeader';
+import ActionRow from '@components/ActionRow';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
 import Button from '@components/Button';
-import ActionRow from '@components/ActionRow';
-import AlertPanel from '@components/AlertPanel';
+import LoaderSpinner from '@components/LoaderSpinner';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import PageHeader from '@components/PageHeader';
+import ProgressCard from '@components/ProgressCard';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, P } from '@components/Typography';
 
 const INCREMENT = 100;
 
@@ -34,7 +32,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -1,13 +1,13 @@
 import S from '@pages/index.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
 import * as Logos from '@components/PartnerLogoSVG';
+import * as React from 'react';
 
-import Page from '@components/Page';
-import Chart from '@components/Chart';
 import * as C from '@common/constants';
+import Chart from '@components/Chart';
+import Page from '@components/Page';
 
 import Footer from '@root/components/Footer';
 import ResponsiveNavbar from '@root/components/ResponsiveNavbar';
@@ -16,7 +16,7 @@ export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 
@@ -130,7 +130,7 @@ function EcosystemPage(props: any) {
 
   React.useEffect(() => {
     const load = async () => {
-      const data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost)
+      const data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost);
 
       let dealsAttempted = 0;
       let dealsAttemptedSet = [];

--- a/pages/errors/[id].tsx
+++ b/pages/errors/[id].tsx
@@ -1,14 +1,13 @@
-import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -23,7 +22,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, ...context.params, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, ...context.params, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -31,7 +31,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,20 +1,12 @@
 import styles from '@pages/new-index.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Page from '@components/Page';
-import Navigation from '@components/Navigation';
-import Card from '@components/Card';
-import Button from '@components/Button';
-import FeatureRow from '@components/FeatureRow';
-import MarketingCube from '@components/MarketingCube';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import Chart from '@components/Chart';
 import * as C from '@common/constants';
-import { H1, H2, H3, H4, P } from '@components/Typography';
-import { MarketingUpload, MarketingProgress, MarketingGraph } from '@components/Marketing';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 
 const curl = `curl \n-X POST https://api.estuary.tech/content/add \n-H "Authorization: Bearer YOUR_API_KEY" \n-H "Accept: application/json" \n-H "Content-Type: multipart/form-data" \n-F "data=@PATH_TO_FILE"`;
 
@@ -24,7 +16,7 @@ export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 
@@ -64,8 +56,7 @@ function IndexPage(props: any) {
     async function load() {
       let data;
       try {
-        data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost)
-
+        data = await R.get('/api/v1/stats/deal-metrics', C.api.metricsHost);
       } catch (e) {
         console.log(e);
         return null;

--- a/pages/proposals/[cid].tsx
+++ b/pages/proposals/[cid].tsx
@@ -22,7 +22,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, ...context.params, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, ...context.params, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/providers/deals/[id].tsx
+++ b/pages/providers/deals/[id].tsx
@@ -1,20 +1,19 @@
-import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
 
   return {
-    props: { viewer, ...context.params, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, ...context.params, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/providers/errors/[id].tsx
+++ b/pages/providers/errors/[id].tsx
@@ -1,20 +1,19 @@
-import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
 
   return {
-    props: { viewer, ...context.params, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, ...context.params, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/providers/public/watch.tsx
+++ b/pages/providers/public/watch.tsx
@@ -1,26 +1,23 @@
 import styles from '@pages/app.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import ProgressCard from '@components/ProgressCard';
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import SingleColumnLayout from '@components/SingleColumnLayout';
 import LoaderSpinner from '@components/LoaderSpinner';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 import StatRow from '@components/StatRow';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/providers/stats/[id].tsx
+++ b/pages/providers/stats/[id].tsx
@@ -1,24 +1,21 @@
-import styles from '@pages/app.module.scss';
-import tstyles from '@pages/table.module.scss';
-
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
 import Block from '@components/Block';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
 
   return {
-    props: { viewer, ...context.params, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, ...context.params, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/receipts/[id].tsx
+++ b/pages/receipts/[id].tsx
@@ -1,15 +1,13 @@
-import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
-import * as C from '@common/constants';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -24,7 +22,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, ...context.params, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, ...context.params, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,23 +1,20 @@
 import styles from '@pages/app.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
-import * as R from '@common/requests';
-import * as C from '@common/constants';
 import * as Crypto from '@common/crypto';
+import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import ProgressCard from '@components/ProgressCard';
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import Input from '@components/Input';
 import Button from '@components/Button';
+import Input from '@components/Input';
 import LoaderSpinner from '@components/LoaderSpinner';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, H3, H4, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -34,7 +31,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { host, protocol, viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { host, protocol, viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -1,25 +1,23 @@
 import styles from '@pages/app.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as C from '@common/constants';
-import * as R from '@common/requests';
-import * as Flags from '@common/flags';
 import * as Crypto from '@common/crypto';
+import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Cookies from 'js-cookie';
-import Page from '@components/Page';
-import Navigation from '@components/Navigation';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import Input from '@components/Input';
 import Button from '@components/Button';
+import Input from '@components/Input';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
+import Cookies from 'js-cookie';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, H3, H4, P } from '@components/Typography';
 
 const ENABLE_SIGN_IN_WITH_FISSION = false;
 
 export async function getServerSideProps(context) {
-
   const viewer = await U.getViewerFromHeader(context.req.headers);
   const host = context.req.headers.host;
   const protocol = host.split(':')[0] === 'localhost' ? 'http' : 'https';
@@ -34,7 +32,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { host, protocol, api: process.env.ESTUARY_API, hostname: `https://${host}` },
+    props: { host, protocol, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${host}` },
   };
 }
 
@@ -43,23 +41,20 @@ async function handleTokenAuthenticate(state: any, host) {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${state.key}`,
+      Authorization: `Bearer ${state.key}`,
     },
   });
   if (response && response.status === 403) {
-    alert("Invalid API key");
-  }
-  else if (response && response.status === 401) {
+    alert('Invalid API key');
+  } else if (response && response.status === 401) {
     alert('Expired API key');
-  }
-  else {
+  } else {
     Cookies.set(C.auth, state.key);
     window.location.reload();
   }
   return response;
 }
 async function handleSignIn(state: any, host) {
-
   if (U.isEmpty(state.username)) {
     return { error: 'Please provide a username.' };
   }
@@ -140,11 +135,7 @@ async function handleSignIn(state: any, host) {
   return;
 }
 
-
-
 function SignInPage(props: any) {
-
-
   const [state, setState] = React.useState({ loading: false, authLoading: false, fissionLoading: false, username: '', password: '', key: '' });
 
   const authorise = null;
@@ -231,13 +222,13 @@ function SignInPage(props: any) {
             loading={state.authLoading ? state.authLoading : undefined}
             onClick={async () => {
               setState({ ...state, authLoading: true });
-              if(U.isEmpty(state.key)){
+              if (U.isEmpty(state.key)) {
                 alert('Please enter an API key');
                 setState({ ...state, authLoading: false });
                 return;
               }
               await handleTokenAuthenticate(state, props.api).then((response) => {
-                if(response.status == 403){
+                if (response.status == 403) {
                   setState({ ...state, authLoading: false });
                 }
               });

--- a/pages/sign-up.tsx
+++ b/pages/sign-up.tsx
@@ -1,19 +1,18 @@
 import styles from '@pages/app.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as C from '@common/constants';
-import * as Flags from '@common/flags';
 import * as Crypto from '@common/crypto';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Cookies from 'js-cookie';
-import Page from '@components/Page';
-import Navigation from '@components/Navigation';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import Input from '@components/Input';
 import Button from '@components/Button';
+import Input from '@components/Input';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
+import Cookies from 'js-cookie';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, H3, H4, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -30,7 +29,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, host, protocol, api: process.env.ESTUARY_API, hostname: `https://${host}` },
+    props: { viewer, host, protocol, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${host}` },
   };
 }
 
@@ -70,7 +69,6 @@ async function handleRegister(state: any, host) {
       error: 'Your username must be 1-48 uppercase or lowercase characters or digits with no spaces.',
     };
   }
-
 
   let passwordHash = await Crypto.attemptHashWithSalt(state.password);
 

--- a/pages/staging.tsx
+++ b/pages/staging.tsx
@@ -27,7 +27,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -37,7 +37,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/upload-disabled.tsx
+++ b/pages/upload-disabled.tsx
@@ -1,22 +1,16 @@
 import styles from '@pages/app.module.scss';
-import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
 import * as U from '@common/utilities';
-import * as R from '@common/requests';
+import * as React from 'react';
 
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
-import ActionRow from '@components/ActionRow';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import Block from '@components/Block';
-import Input from '@components/Input';
 import Button from '@components/Button';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -31,7 +25,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/upload.tsx
+++ b/pages/upload.tsx
@@ -1,20 +1,19 @@
 import styles from '@pages/app.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
-import * as C from '@common/constants';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Page from '@components/Page';
-import Navigation from '@components/Navigation';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import UploadZone from '@components/UploadZone';
-import UploadList from '@components/UploadList';
 import Button from '@components/Button';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
+import UploadList from '@components/UploadList';
+import UploadZone from '@components/UploadZone';
 
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import { H2, H3, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -38,7 +37,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/verify-cid.tsx
+++ b/pages/verify-cid.tsx
@@ -1,19 +1,19 @@
 import S from '@pages/index.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Page from '@components/Page';
-import Navigation from '@components/Navigation';
-import Button from '@components/Button';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import Input from '@components/Input';
-import StatRow from '@components/StatRow';
-import LoaderSpinner from '@components/LoaderSpinner';
-import RetrievalCommands from '@components/RetrievalCommands';
 import * as C from '@common/constants';
-import { H1, H2, H3, H4, P } from '@components/Typography';
+import Button from '@components/Button';
+import Input from '@components/Input';
+import LoaderSpinner from '@components/LoaderSpinner';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import RetrievalCommands from '@components/RetrievalCommands';
+import SingleColumnLayout from '@components/SingleColumnLayout';
+import StatRow from '@components/StatRow';
+import { H1, H2, H3, P } from '@components/Typography';
 
 // NOTE(jim): test CIDs
 // QmYNSTn2XrxDsF3qFdeYKSxjodsbswJV3mj1ffEJZa2jQL
@@ -23,7 +23,7 @@ export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
 
   return {
-    props: { viewer, api: process.env.ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+    props: { viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
   };
 }
 

--- a/pages/your-miners.tsx
+++ b/pages/your-miners.tsx
@@ -1,24 +1,19 @@
 import styles from '@pages/app.module.scss';
 import tstyles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as R from '@common/requests';
-import * as C from '@common/constants';
-import * as Crypto from '@common/crypto';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import ProgressCard from '@components/ProgressCard';
-import Navigation from '@components/Navigation';
-import Page from '@components/Page';
 import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
-import SingleColumnLayout from '@components/SingleColumnLayout';
-import EmptyStatePlaceholder from '@components/EmptyStatePlaceholder';
-import Input from '@components/Input';
 import Button from '@components/Button';
-import LoaderSpinner from '@components/LoaderSpinner';
+import Input from '@components/Input';
+import Navigation from '@components/Navigation';
+import Page from '@components/Page';
+import SingleColumnLayout from '@components/SingleColumnLayout';
 
-import { H1, H2, H3, H4, P, CodeBlock } from '@components/Typography';
+import { CodeBlock, H2, H3, H4, P } from '@components/Typography';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -35,7 +30,7 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { host, protocol, viewer, api: process.env.ESTUARY_API, hostname: `https://${host}` },
+    props: { host, protocol, viewer, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${host}` },
   };
 }
 


### PR DESCRIPTION
Allows the env variables to be accessible from in-browser. This fixes our dev-production mode for pages not rendered server-side, like /ecosystem.

All other changes are on-save auto formatting.

Reference: https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser