### PR TITLE
Render pinning status icon in contents tables

### DIFF
--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -2,6 +2,7 @@ import * as U from '@common/utilities';
 import tstyles from '@pages/files-table.module.scss';
 import React, { useMemo, useState } from 'react';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
+import PinStatusIcon from './PinStatusIcon';
 
 const FilesTable = ({ files }) => {
   const [gateway, setGateway] = useState('https://gateway.estuary.tech/gw/ipfs/');
@@ -15,7 +16,6 @@ const FilesTable = ({ files }) => {
         disableFilters: true,
         width: '7.8em',
       },
-
       {
         id: 'Name',
         Header: 'Name',
@@ -30,12 +30,16 @@ const FilesTable = ({ files }) => {
           }
 
           const lk = data.cid != null ? gateway + (data.cid['/'] || data.cid) : '/';
-          return { name, lk };
+          const pinStatus = data.pinningStatus;
+          return { name, lk, pinStatus };
         },
         Cell: ({ value }) => (
-          <a href={value.lk} style={{ overflowWrap: 'break-word' }} target="_blank" className={tstyles.cta}>
-            {value.name}
-          </a>
+          <div style={{ display: 'block' }}>
+            <PinStatusIcon pinningStatus={value.pinStatus} />
+            <a href={value.lk} style={{ overflowWrap: 'break-word' }} target="_blank" className={tstyles.cta}>
+              {value.name}
+            </a>
+          </div>
         ),
         width: '45%',
         Filter: DefaultColumnFilter,

--- a/components/PinStatusIcon.module.scss
+++ b/components/PinStatusIcon.module.scss
@@ -1,4 +1,4 @@
 .statusIcon {
-  font-size: 1.25em !important;
+  font-size: 1.5em !important;
   float: right;
 }

--- a/components/PinStatusIcon.module.scss
+++ b/components/PinStatusIcon.module.scss
@@ -1,0 +1,4 @@
+.statusIcon {
+  font-size: 1.25em !important;
+  float: right;
+}

--- a/components/PinStatusIcon.tsx
+++ b/components/PinStatusIcon.tsx
@@ -1,30 +1,36 @@
 import styles from '@components/PinStatusIcon.module.scss';
-import { MoveDownOutlined, PublishedWithChangesOutlined, SyncOutlined, SyncProblemOutlined } from '@mui/icons-material';
+import { HourglassEmptyOutlined, MoveDownOutlined, PublishedWithChangesOutlined, SyncOutlined, SyncProblemOutlined } from '@mui/icons-material';
 import { Tooltip } from '@mui/material';
 
 function PinStatusIcon(props: any) {
-  if (props.pinningStatus == 'pinned') {
+  if (props.pinningStatus == 'queued') {
     return (
-      <Tooltip title={props.pinningStatus}>
-        <PublishedWithChangesOutlined color="success" className={styles.statusIcon} />
+      <Tooltip title={props.pinningStatus} placement="left" arrow>
+        <HourglassEmptyOutlined color="secondary" fontSize="small" className={styles.statusIcon} />
       </Tooltip>
     );
   } else if (props.pinningStatus == 'pinning') {
     return (
-      <Tooltip title={props.pinningStatus}>
-        <SyncOutlined color="primary" className={styles.statusIcon} />
+      <Tooltip title={props.pinningStatus} placement="left" arrow>
+        <SyncOutlined color="primary" fontSize="small" className={styles.statusIcon} />
+      </Tooltip>
+    );
+  } else if (props.pinningStatus == 'pinned') {
+    return (
+      <Tooltip title={props.pinningStatus} placement="left" arrow>
+        <PublishedWithChangesOutlined color="success" fontSize="small" className={styles.statusIcon} />
       </Tooltip>
     );
   } else if (props.pinningStatus == 'failed') {
     return (
-      <Tooltip title={props.pinningStatus}>
-        <SyncProblemOutlined color="error" className={styles.statusIcon} />
+      <Tooltip title={props.pinningStatus} placement="left" arrow>
+        <SyncProblemOutlined color="error" fontSize="small" className={styles.statusIcon} />
       </Tooltip>
     );
   } else if (props.pinningStatus == 'offloaded') {
     return (
-      <Tooltip title={props.pinningStatus}>
-        <MoveDownOutlined color="disabled" className={styles.statusIcon} />
+      <Tooltip title={props.pinningStatus} placement="left" arrow>
+        <MoveDownOutlined color="disabled" fontSize="small" className={styles.statusIcon} />
       </Tooltip>
     );
   }

--- a/components/PinStatusIcon.tsx
+++ b/components/PinStatusIcon.tsx
@@ -1,0 +1,34 @@
+import styles from '@components/PinStatusIcon.module.scss';
+import { MoveDownOutlined, PublishedWithChangesOutlined, SyncOutlined, SyncProblemOutlined } from '@mui/icons-material';
+import { Tooltip } from '@mui/material';
+
+function PinStatusIcon(props: any) {
+  if (props.pinningStatus == 'pinned') {
+    return (
+      <Tooltip title={props.pinningStatus}>
+        <PublishedWithChangesOutlined color="success" className={styles.statusIcon} />
+      </Tooltip>
+    );
+  } else if (props.pinningStatus == 'pinning') {
+    return (
+      <Tooltip title={props.pinningStatus}>
+        <SyncOutlined color="primary" className={styles.statusIcon} />
+      </Tooltip>
+    );
+  } else if (props.pinningStatus == 'failed') {
+    return (
+      <Tooltip title={props.pinningStatus}>
+        <SyncProblemOutlined color="error" className={styles.statusIcon} />
+      </Tooltip>
+    );
+  } else if (props.pinningStatus == 'offloaded') {
+    return (
+      <Tooltip title={props.pinningStatus}>
+        <MoveDownOutlined color="disabled" className={styles.statusIcon} />
+      </Tooltip>
+    );
+  }
+  return null;
+}
+
+export default PinStatusIcon;

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.18.9",
-    "@emotion/react": "^11.10.5",
-    "@emotion/styled": "^11.10.5",
     "@glif/filecoin-number": "^1.1.0-beta.17",
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.18.9",
+    "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
     "@glif/filecoin-number": "^1.1.0-beta.17",
+    "@mui/icons-material": "^5.11.0",
+    "@mui/material": "^5.11.0",
     "@types/node": "^17.0.13",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",

--- a/pages/files-table.module.scss
+++ b/pages/files-table.module.scss
@@ -80,7 +80,8 @@
 }
 
 .td {
-  padding: 1em;
+  line-height: 1.5em;
+  padding: 0.5em;
   overflow: hidden;
   text-overflow: ellipsis;
   @media (max-width: 960px) {

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -38,7 +38,7 @@ export async function getServerSideProps(context) {
 const getNext = async (state, setState, host) => {
   const offset = state.offset + INCREMENT;
   const limit = state.limit;
-  const next = await R.get(`/content/stats?offset=${offset}&limit=${limit}`, host);
+  const next = await R.get(`/content/contents?offset=${offset}&limit=${limit}`, host);
 
   if (!next || !next.length) {
     return;
@@ -62,7 +62,7 @@ function HomePage(props: any) {
 
   React.useEffect(() => {
     const run = async () => {
-      const files = await R.get(`/content/stats?offset=${state.offset}&limit=${state.limit}`, props.api);
+      const files = await R.get(`/content/contents?offset=${state.offset}&limit=${state.limit}`, props.api);
       const stats = await R.get('/user/stats', props.api);
 
       if (files && !files.error) {

--- a/pages/index.module.scss
+++ b/pages/index.module.scss
@@ -574,7 +574,7 @@ a.flink {
   
   @media (max-width: 768px) {
     width: 100%;
-    padding: 1em;
+    padding: 0.5em;
     flex-direction: column;
   }
 }


### PR DESCRIPTION
blocked on https://github.com/application-research/estuary/pull/772

![image](https://user-images.githubusercontent.com/2850013/207511084-476c4fb2-302c-4222-9cd8-8feb12a6529f.png)

add icons with tooltips for each pinning statuses (demonstrated in order in screenshot):
- queued
- pinning
- pinned
- failed
- offloaded


Note: the statuses in the above screenshot are manufactured, it will typically look more like below (with healthy estuary)
![image](https://user-images.githubusercontent.com/2850013/207513487-99ee828b-02be-4263-8d04-a5d0ed2477ef.png)
