### PR TITLE
Fix environment variables not set

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "node": "14.x"
   },
   "scripts": {
-    "dev": "NEXT_PUBLIC_ESTUARY_API=http://localhost:3004 next dev -p 4444",
+    "dev": "NEXT_PUBLIC_ESTUARY_API=${ESTUARY_API:-http://localhost:3004} next dev -p 4444",
     "dev-docker": "NEXT_PUBLIC_ESTUARY_API=${ESTUARY_API:-http://localhost:3004} next dev -p 4444",
-    "dev-production": "NEXT_PUBLIC_ESTUARY_API=https://api.estuary.tech NEXT_PUBLIC_ESTUARY_METRICS_API=https://metrics-api.estuary.tech next dev -p 4444",
+    "dev-production": "NEXT_PUBLIC_ESTUARY_API=${ESTUARY_API:-https://api.estuary.tech} NEXT_PUBLIC_ESTUARY_METRICS_API=https://metrics-api.estuary.tech next dev -p 4444",
     "build": "next build",
     "check-types": "tsc --noemit",
     "start": "NODE_ENV=production next start",


### PR DESCRIPTION
When setting the `ESTUARY_API` environment variable it was not being set on the code. This fixes it.