### PR TITLE
Fix add-ipfs body

### DIFF
--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -109,7 +109,7 @@ function UploadCIDPage(props: any) {
                   `/content/add-ipfs`,
                   {
                     filename: state.filename,
-                    root: state.cid,
+                    cid: state.cid,
                   },
                   props.api
                 );
@@ -146,7 +146,7 @@ function UploadCIDPage(props: any) {
                     `/content/add-ipfs`,
                     {
                       name: state.filename,
-                      root: state.cid,
+                      cid: state.cid,
                     },
                     props.api
                   );


### PR DESCRIPTION
currently throws an error "cid too short", at some point we changed the expected body from { name, root } to { name, cid } but didn't update the front end