### PR TITLE
Revert "Remove unused @emotion dep"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.18.9",
+    "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
     "@glif/filecoin-number": "^1.1.0-beta.17",
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.0",


### PR DESCRIPTION
This reverts commit 6f8b2c6c2dc0ccaf76d033a4a2b14c9de31bae79.

Turns out these libs are needed by material ui to build. See failed render build without them: https://dashboard.render.com/web/srv-c249sqjs1ghc004rv0n0/deploys/dep-ced5jocgqg45ht8b60og

