### PR TITLE
Bump next to 13, Use Link for prefetching

### DIFF
--- a/components/AuthenticatedSidebar.tsx
+++ b/components/AuthenticatedSidebar.tsx
@@ -1,10 +1,9 @@
 import styles from '@components/AuthenticatedSidebar.module.scss';
 import Cookies from 'js-cookie';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as C from '@common/constants';
 import * as R from '@common/requests';
+import Link from 'next/link';
 
 function AuthenticatedLayout(props: any) {
   let perms = 0;
@@ -17,41 +16,41 @@ function AuthenticatedLayout(props: any) {
       <div className={styles.title} style={{ marginTop: 40 }}>
         Home
       </div>
-      <a className={styles.item} href="/home" style={props.active === 'FILES' ? { color: `var(--main-primary)` } : null}>
+      <Link className={styles.item} href="/home" style={props.active === 'FILES' ? { color: `var(--main-primary)` } : null}>
         Files
-      </a>
-      <a className={styles.item} href="/upload" style={props.active === 'UPLOAD' ? { color: `var(--main-primary)` } : null}>
+      </Link>
+      <Link className={styles.item} href="/upload" style={props.active === 'UPLOAD' ? { color: `var(--main-primary)` } : null}>
         Upload
-      </a>
-      <a className={styles.item} href="/upload-cid" style={props.active === 'UPLOAD_CID' ? { color: `var(--main-primary)` } : null}>
+      </Link>
+      <Link className={styles.item} href="/upload-cid" style={props.active === 'UPLOAD_CID' ? { color: `var(--main-primary)` } : null}>
         Pin CID
-      </a>
+      </Link>
 
       <div className={styles.title}>Developers</div>
-      <a className={styles.item} href="/staging" style={props.active === 'STAGING' ? { color: `var(--main-primary)` } : null}>
+      <Link className={styles.item} href="/staging" style={props.active === 'STAGING' ? { color: `var(--main-primary)` } : null}>
         Staging
-      </a>
-      <a className={styles.item} href="/deals" style={props.active === 'DEALS' ? { color: `var(--main-primary)` } : null}>
+      </Link>
+      <Link className={styles.item} href="/deals" style={props.active === 'DEALS' ? { color: `var(--main-primary)` } : null}>
         Deals
-      </a>
-      <a className={styles.item} href="/deals/debug" style={props.active === 'DEALS_DEBUG' ? { color: `var(--main-primary)` } : null}>
+      </Link>
+      <Link className={styles.item} href="/deals/debug" style={props.active === 'DEALS_DEBUG' ? { color: `var(--main-primary)` } : null}>
         Debug
-      </a>
-      <a className={styles.item} href="/api-admin" style={props.active === 'API' ? { color: `var(--main-primary)` } : null}>
+      </Link>
+      <Link className={styles.item} href="/api-admin" style={props.active === 'API' ? { color: `var(--main-primary)` } : null}>
         API keys
-      </a>
+      </Link>
 
       <div className={styles.title}>Settings</div>
-      <a className={styles.item} href="/your-miners">
+      <Link className={styles.item} href="/your-miners">
         Your miners
-      </a>
+      </Link>
 
-      <a className={styles.item} href="/settings">
+      <Link className={styles.item} href="/settings">
         Account
-      </a>
-      <a className={styles.item} href="https://docs.estuary.tech/feedback" target="_blank">
+      </Link>
+      <Link className={styles.item} href="https://docs.estuary.tech/feedback" target="_blank">
         Feedback
-      </a>
+      </Link>
       <span
         className={styles.item}
         onClick={async () => {
@@ -66,44 +65,44 @@ function AuthenticatedLayout(props: any) {
 
       {perms >= 10 ? <div className={styles.title}>Admin</div> : null}
       {perms >= 10 ? (
-        <a className={styles.item} href="/admin/impersonate" style={props.active === 'ADMIN_IMPERSONATE' ? { color: `var(--main-primary)` } : null}>
+        <Link className={styles.item} href="/admin/impersonate" style={props.active === 'ADMIN_IMPERSONATE' ? { color: `var(--main-primary)` } : null}>
           Impersonate
-        </a>
+        </Link>
       ) : null}
       {perms >= 10 ? (
-        <a className={styles.item} href="/admin/stats" style={props.active === 'ADMIN_STATS' ? { color: `var(--main-primary)` } : null}>
+        <Link className={styles.item} href="/admin/stats" style={props.active === 'ADMIN_STATS' ? { color: `var(--main-primary)` } : null}>
           System
-        </a>
+        </Link>
       ) : null}
       {perms >= 10 ? (
-        <a className={styles.item} href="/admin/balance" style={props.active === 'ADMIN_BALANCE' ? { color: `var(--main-primary)` } : null}>
+        <Link className={styles.item} href="/admin/balance" style={props.active === 'ADMIN_BALANCE' ? { color: `var(--main-primary)` } : null}>
           Balance
-        </a>
+        </Link>
       ) : null}
       {perms >= 10 ? (
-        <a className={styles.item} href="/admin/providers" style={props.active === 'ADMIN_MINERS' ? { color: `var(--main-primary)` } : null}>
+        <Link className={styles.item} href="/admin/providers" style={props.active === 'ADMIN_MINERS' ? { color: `var(--main-primary)` } : null}>
           Providers
-        </a>
+        </Link>
       ) : null}
       {perms >= 10 ? (
-        <a className={styles.item} href="/admin/content" style={props.active === 'ADMIN_CONTENT' ? { color: `var(--main-primary)` } : null}>
+        <Link className={styles.item} href="/admin/content" style={props.active === 'ADMIN_CONTENT' ? { color: `var(--main-primary)` } : null}>
           Content
-        </a>
+        </Link>
       ) : null}
       {perms >= 10 ? (
-        <a className={styles.item} href="/admin/users" style={props.active === 'ADMIN_USERS' ? { color: `var(--main-primary)` } : null}>
+        <Link className={styles.item} href="/admin/users" style={props.active === 'ADMIN_USERS' ? { color: `var(--main-primary)` } : null}>
           Users
-        </a>
+        </Link>
       ) : null}
       {perms >= 10 ? (
-        <a className={styles.item} href="/admin/invites" style={props.active === 'ADMIN_INVITES' ? { color: `var(--main-primary)` } : null}>
+        <Link className={styles.item} href="/admin/invites" style={props.active === 'ADMIN_INVITES' ? { color: `var(--main-primary)` } : null}>
           Invites
-        </a>
+        </Link>
       ) : null}
       {perms >= 10 ? (
-        <a className={styles.item} href="/admin/shuttle" style={props.active === 'ADMIN_SHUTTLE' ? { color: `var(--main-primary)` } : null}>
+        <Link className={styles.item} href="/admin/shuttle" style={props.active === 'ADMIN_SHUTTLE' ? { color: `var(--main-primary)` } : null}>
           Shuttle
-        </a>
+        </Link>
       ) : null}
     </nav>
   );

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
 import * as U from '@common/utilities';
 
 import styles from '@components/Button.module.scss';
 
 import LoaderSpinner from '@components/LoaderSpinner';
+import Link from 'next/link';
 
 const Button = (props: any) => {
   if (props.loading) {
@@ -19,7 +19,7 @@ const Button = (props: any) => {
   }
 
   if (!U.isEmpty(props.href)) {
-    return <a href={props.href} className={styles.button} children={props.children} {...props} />;
+    return <Link href={props.href} className={styles.button} children={props.children} {...props} />;
   }
 
   return <button style={props.style} className={styles.button} onClick={props.onClick} children={props.children} />;

--- a/components/ComparisonWeb3.tsx
+++ b/components/ComparisonWeb3.tsx
@@ -1,9 +1,6 @@
 import styles from '@components/Comparison.module.scss';
 import tstyles from '@pages/table.module.scss';
-
-import * as React from 'react';
-import * as U from '@common/utilities';
-import * as C from '@common/constants';
+import Link from 'next/link';
 
 function ComparisonWeb3(props: any) {
   return (
@@ -360,9 +357,9 @@ function ComparisonWeb3(props: any) {
               <br />
               <br />
               Example:{' '}
-              <a href="/providers/stats/f02620" target="_blank">
+              <Link href="/providers/stats/f02620" target="_blank">
                 here
-              </a>
+              </Link>
               .
             </td>
 
@@ -379,9 +376,9 @@ function ComparisonWeb3(props: any) {
               <br />
               <br />
               Example:{' '}
-              <a href="/verify-cid?cid=QmVrrF7DTnbqKvWR7P7ihJKp4N5fKmBX29m5CHbW9WLep9" target="_blank">
+              <Link href="/verify-cid?cid=QmVrrF7DTnbqKvWR7P7ihJKp4N5fKmBX29m5CHbW9WLep9" target="_blank">
                 here
-              </a>
+              </Link>
               .
             </td>
 

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -41,9 +41,13 @@ const FilesTable = ({ files }) => {
         Cell: ({ value }) => (
           <div style={{ display: 'block' }}>
             <PinStatusIcon pinningStatus={value.pinStatus} />
-            <Link href={value.lk} style={{ overflowWrap: 'break-word' }} target="_blank" className={tstyles.cta}>
-              {value.name}
-            </Link>
+            {value.lk ? (
+              <Link href={value.lk} style={{ overflowWrap: 'break-word' }} target="_blank" className={tstyles.cta}>
+                {value.name}
+              </Link>
+            ) : (
+              value.name
+            )}
           </div>
         ),
         width: '45%',

--- a/components/FilesTable.tsx
+++ b/components/FilesTable.tsx
@@ -1,5 +1,6 @@
 import * as U from '@common/utilities';
 import tstyles from '@pages/files-table.module.scss';
+import Link from 'next/link';
 import React, { useMemo, useState } from 'react';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 import PinStatusIcon from './PinStatusIcon';
@@ -40,9 +41,9 @@ const FilesTable = ({ files }) => {
         Cell: ({ value }) => (
           <div style={{ display: 'block' }}>
             <PinStatusIcon pinningStatus={value.pinStatus} />
-            <a href={value.lk} style={{ overflowWrap: 'break-word' }} target="_blank" className={tstyles.cta}>
+            <Link href={value.lk} style={{ overflowWrap: 'break-word' }} target="_blank" className={tstyles.cta}>
               {value.name}
-            </a>
+            </Link>
           </div>
         ),
         width: '45%',

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,11 +1,12 @@
 import styles from '@components/Footer.module.scss';
+import Link from 'next/link';
 
 function FooterLink({ children, href }: { href: string, children: React.ReactNode }) {
   return (
     <li className={styles.listItemLink}>
-      <a className={styles.footerLink} style={{ textDecoration: 'none' }} href={href} target="_blank">
+      <Link className={styles.footerLink} style={{ textDecoration: 'none' }} href={href} target="_blank">
         {children}
-      </a>
+      </Link>
     </li>
   );
 }
@@ -40,14 +41,14 @@ function Footer() {
       <section className={styles.footerBranding}>
         <div className={styles.footerBrandingContent}>
           <div className={styles.footerLeft}>
-            <a href="https://estuary.tech/" target="_blank">
+            <Link href="https://estuary.tech/" target="_blank">
               <img className={styles.footerLogo} height="24px" src="https://user-images.githubusercontent.com/28320272/204942093-88d8027a-2e0f-4d41-877e-1a462ab15c8d.svg" />
-            </a>
+            </Link>
           </div>
           <div className={styles.footerRight}>
-            <a href={'https://arg.protocol.ai'} style={{ textDecoration: 'none', color: 'black', whiteSpace: 'nowrap' }}>
+            <Link href={'https://arg.protocol.ai'} style={{ textDecoration: 'none', color: 'black', whiteSpace: 'nowrap' }}>
               @2022 ARG
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/components/MarketingCube.tsx
+++ b/components/MarketingCube.tsx
@@ -1,12 +1,11 @@
 import styles from '@components/MarketingCube.module.scss';
 
-import * as React from 'react';
 import * as U from '@common/utilities';
-import * as C from '@common/constants';
+import Link from 'next/link';
 
 function MarketingCube(props: any) {
   return (
-    <a className={styles.scene} href="/sign-up">
+    <Link className={styles.scene} href="/sign-up">
       <div className={styles.cube}>
         <div className={U.classNames(styles.face, styles.front)}>{props.children}</div>
         <div className={U.classNames(styles.face, styles.back)}>{props.children}</div>
@@ -15,7 +14,7 @@ function MarketingCube(props: any) {
         <div className={U.classNames(styles.face, styles.top)}>{props.children}</div>
         <div className={U.classNames(styles.face, styles.bottom)}>{props.children}</div>
       </div>
-    </a>
+    </Link>
   );
 }
 

--- a/components/MinerTable.tsx
+++ b/components/MinerTable.tsx
@@ -1,8 +1,8 @@
 import styles from '@pages/table.module.scss';
 
-import * as React from 'react';
-import * as C from '@common/constants';
 import * as U from '@common/utilities';
+import Link from 'next/link';
+import * as React from 'react';
 
 export default class MinerTable extends React.Component<any> {
   static defaultProps = {
@@ -29,16 +29,16 @@ export default class MinerTable extends React.Component<any> {
               return (
                 <tr className={styles.tr} key={`${miner.miner}-${index}`}>
                   <td className={styles.tdcta}>
-                    <a className={styles.cta} href={`/providers/stats/${miner.addr}`}>
+                    <Link className={styles.cta} href={`/providers/stats/${miner.addr}`}>
                       {miner.addr} {!U.isEmpty(miner.name) ? `(${miner.name})` : ''}
-                    </a>
+                    </Link>
                   </td>
 
                   {miner.totalDeals ? (
                     <td className={styles.tdcta}>
-                      <a className={styles.cta} href={`/providers/deals/${miner.addr}`}>
+                      <Link className={styles.cta} href={`/providers/deals/${miner.addr}`}>
                         {miner.totalDeals} deals
-                      </a>
+                      </Link>
                     </td>
                   ) : (
                     <td className={styles.td} />
@@ -46,9 +46,9 @@ export default class MinerTable extends React.Component<any> {
                   {miner.confirmedDeals ? <td className={styles.td}>{miner.confirmedDeals} deals</td> : <td className={styles.td} />}
                   {miner.failedDeals ? (
                     <td className={styles.tdcta}>
-                      <a className={styles.cta} href={`/providers/errors/${miner.addr}`} target="_blank">
+                      <Link className={styles.cta} href={`/providers/errors/${miner.addr}`} target="_blank">
                         {miner.failedDeals} deals
-                      </a>
+                      </Link>
                     </td>
                   ) : (
                     <td className={styles.td} />
@@ -80,9 +80,9 @@ export default class MinerTable extends React.Component<any> {
               return (
                 <tr className={styles.tr} key={`${miner.miner}-${index}`} style={suspended}>
                   <td className={styles.tdcta}>
-                    <a className={styles.cta} href={`/providers/stats/${miner.addr}`}>
+                    <Link className={styles.cta} href={`/providers/stats/${miner.addr}`}>
                       {miner.addr}
-                    </a>
+                    </Link>
                   </td>
                   <td className={styles.td} style={suspended}>
                     {miner.suspendedReason}

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,49 +1,46 @@
 import styles from '@components/Navigation.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
-import * as C from '@common/constants';
-
 import Tag from '@components/Tag';
+import Link from 'next/link';
 
 const Navigation = (props: any) => {
   return (
     <div className={styles.navigation}>
       <nav className={styles.container} style={props.style}>
         <div className={styles.left} style={{ backgroundColor: !props.isRenderingSidebar ? `#fff` : null }}>
-          <a className={styles.logo} href="/">
+          <Link className={styles.logo} href="/">
             Estuary <Tag>Alpha</Tag>
-          </a>
+          </Link>
         </div>
         <div className={styles.right}>
           {!props.isAuthenticated && props.active !== 'SIGN_UP' ? (
-            <a href="/sign-up" className={styles.item}>
+            <Link href="/sign-up" className={styles.item}>
               Sign up
-            </a>
+            </Link>
           ) : null}
           {!props.isAuthenticated && props.active !== 'SIGN_IN' ? (
-            <a href="/sign-in" className={styles.item}>
+            <Link href="/sign-in" className={styles.item}>
               Sign in
-            </a>
+            </Link>
           ) : null}
           {props.isAuthenticated && props.active === 'INDEX' ? (
-            <a href="/home" className={styles.item}>
+            <Link href="/home" className={styles.item}>
               Home
-            </a>
+            </Link>
           ) : null}
 
-          <a href="/verify-cid" className={styles.webItem}>
+          <Link href="/verify-cid" className={styles.webItem}>
             Verify
-          </a>
+          </Link>
 
-          <a href="https://docs.estuary.tech" className={styles.webItem}>
+          <Link href="https://docs.estuary.tech" className={styles.webItem}>
             Documentation
-          </a>
+          </Link>
 
           {props.isAuthenticated ? (
-            <a href="/_" className={styles.mobileItem}>
+            <Link href="/_" className={styles.mobileItem}>
               Menu
-            </a>
+            </Link>
           ) : null}
         </div>
       </nav>

--- a/components/PartnerLogoSVG.tsx
+++ b/components/PartnerLogoSVG.tsx
@@ -1,26 +1,28 @@
+import Link from 'next/link';
+
 export const GainForest = (props: any) => {
   return (
-    <a href="https://www.gainforest.app/" target="_blank">
+    <Link href="https://www.gainforest.app/" target="_blank">
       <img src="https://user-images.githubusercontent.com/28320272/202937959-1dfe1c3f-a409-4e69-8ea4-934f7203c3fa.png" alt="" style={{ ...props.style }} />
-    </a>
+    </Link>
   );
 };
 
 export const NBFS = (props: any) => {
   return (
-    <a href="https://nbfspool.com/#/" target="_blank">
+    <Link href="https://nbfspool.com/#/" target="_blank">
       <img
         className={props.className}
         src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMUAAAA7CAMAAAD8fr6rAAACfFBMVEVHcEz///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////88FegUAAAA03RSTlMAEDDgIGDwgEDAcFCQoNABCQKwBCLuMv7XAzPW7X79Q1sYREeDiidUFAw4vDy2BynG6yHfiXdIFblF6sf68Z6W9lH86S6PdhuOQR7LPQtk92gWwW8GhDdc4av7yYdsxVXeWU8rE/inaW6lI5V9NTkOqBw7LZ8RbY0k7CYlmE2Byk7RtefkVqJYrYZrc0bZGposzw+ySUrO3bS3DTTaL/OUYmOk4q/TnCq4dbuFzXy/GReCeq4Km4yXP+WsYTpLk1qz5gWxuuP03PKZ79jbPtVdHX8odFDJSgAABmZJREFUaN7dmtVj20gQxj9ZssCYOMxpqGnTNmmTNCkzM3N7ZWa6wt2Vj5mZmZmZGb5/6B5WkiVZjt03q/MiazW7np92dmbHXsBfBo8bv3bdYARb1tduKC29rbY10BBNE/4DgLYJY4JMseZWcW25JcgUlaPFtfn3IFPc1CiuN58PMkXPcHHt/+nKrKAyTDdWjL2xGCjWxp5uGbWwL4gMo/YdWVxS3V1z8mTN6mqg6quy0YFjOL6t+90SAEWrYrFVRQCAPdt2LFseKIjGkVNGZLaGhs8cVBwUhGTjxPKtWR699GJzgVuvlB8EAL3UmJNdKbq5aRjQXn5XYTIMvZdcO/GxqtndTw6sOOX5eKqCNNoKMaxOJklePFQ6Ipdq+3UkyWkFmEKGU0g4t+qrpuqkwqPYbpp2NrfqK6bqnYVHMdU07cPcqq+Zqg8XHsVG07SPcqu+bqruLjyKMfUkyQp+NiqH5qwZI0mSk+8pwCC1uYxk19DdXLRiwYARuax1ZQ3JSw3OVKPrdoLXFXHRdV0POTUskQAAuqZpUbjHcPUAgFBE08KKSyusaRFbSbJGs2XIc7whCXwxj582JrMglGzoGjEXqDrBHldA1tLBzaAmLkLkuGJpWKID0GWSpBpxjSF6xCyzQwnRErctleKiJWFy6GI0tykKABR/Po1d+/2z+6aOcrN32NOVquRLQaqhTAqdJA2SjGdQWD0QJsmESjJhji0lSKqJdEbITgEcbB1fcWxQBkP1xg7row+FMN5BYQBA1KD4oJEOfZmMANATbgoAkh4330hIJTUJUAwyIVQSpKEAkkYylIsCOPMNf+l1b8PPbGl6tjg7hUpV8aEADGG+iyJE66kmeSjS7mnYXpoyX1GYTMGaJiM3BdBcyZ/PAcmGurqGJIBdpxwu7ENhyOZr9VJo4rW5KHQxFd6vNzUkUgNCtsmQVMpiBi23RUqMmosCJZHf2L+ygyQ73nnvzbYlGJgiTNHdhwI+FEZ2CpAaEDOdBrA+h8iYYzZj+VAAfWfrK8RyW/3+abeqDwVkYZmXIiHeo4tCUn0mw0NhUHVSa0DEabJKIz8K4EsralyP3BRhMaKLQokmyGjm6tZIytEsFGEyDLimi4wBMecQYrnlRXHOopiSBwVkJvwibdSy0RBi+QgphyUfiqhKVTINT1MYdpywnSxfijmWJQ35UOhk2C9fhN3ZwBzBIElZd1FommbIZjKwQ7c/hZY/RZHYMbF+Z3EeFDAoe9eFHpGFUcJGTdNs2/S4u56xOYWrOROiD0U8fwpsqifJilq+cSQPCp3UMla3JFPOWBfmViCVTvlpTt25fJ2xVyMlx7pQ86ZAUxc5bsyClkXccTgnBeJUJS8FNFLxp3BmtgwNZ4yKkhEgYq2xq4xRALBuKAAoazi5rigXhUJqGRTim/wpog7v92hoDpvjVr6IezrmTTGkxDTmPOXLOSgQo5pBESMlr42KKxH4UijpUKukc7eSnsTQ1VAYllrV4pFcGhqYQlKpeteFmrkuwqpuv+RsHgXDzoyW34XtbWEkz31UJgVwPDa1/te+gSjSm1uTIhRR7RjlfM2Mh4QxrtXtXvsqGVMAPUHHzjKhA0qM5qzoZMRVe/XtfYqVC5NZPQoA0NlPNfJdSe+PPLV+gR+FJNObL0T28swFScrpnOhHgZBKUqW3vqBKUo1aHumsvbBE/FT2dAbFI8Nctzf8wcpxJMl5RT4UCHso1JTuY6OSMlODjuwUCJmDxNK1Xky0GOlaz0Ux0byZ76W4/0H3/fKZi0zVOmfNbO8/dWfdna6KHZW5uI8662c/Davujroqaynqqbtd1XyZadrsjH9j7vO2XDBVHyq8n0CsiTnmfXD3Hd6Wt6ydQuFRVJqm9XofpKLelo9N1UcLj2KxsKxiuvdXg5Vve1WPjhe6DxQeRXIGSZY1l5fVebLIMO9Gd8XS7SSn3l6Qf8Psb5m0qx2Yu2VnryOGIu75L+CTzkOH586ctK8ThS2dLzxzIJ3q5rir1b3yHgREkv1P2MtjocOjqk70lH+A4Mj8o/MaAKBoVc0Pf1sO9vLjS7ciUFL89ewD1ajurvn+Ss3qagBAz7RSBE8Gf7tMnAP5d+wg4PKy0e0IogyZYZ7JudC65M+/5iOgYp+PulT7T1VQIdJn1S4qCK5cG+cGmya0AYE/w3ltnKcN2tnm/wGo0l3Rqsgq5gAAAABJRU5ErkJggg=="
         style={{ display: 'inline-block', ...props.style }}
       />
-    </a>
+    </Link>
   );
 };
 
 export const Portrait = (props: any) => {
   return (
-    <a href="https://portrait.gg/" target="_blank">
+    <Link href="https://portrait.gg/" target="_blank">
       <svg fill="none" viewBox="0 0 332 72" {...props}>
         <g fill="#FFFFFF">
           <path
@@ -31,13 +33,13 @@ export const Portrait = (props: any) => {
           <path d="M100.172 61.67V11.103h18.708c4.045 0 7.392.674 10.04 2.023 2.649 1.348 4.623 3.202 5.923 5.562 1.301 2.36 1.951 5.009 1.951 7.946 0 2.794-.626 5.37-1.878 7.73-1.252 2.312-3.203 4.19-5.851 5.635-2.649 1.396-6.044 2.095-10.185 2.095h-9.462V61.67h-9.246Zm9.246-27.09h8.884c3.227 0 5.538-.698 6.934-2.094 1.445-1.445 2.167-3.395 2.167-5.852 0-2.504-.722-4.454-2.167-5.85-1.396-1.446-3.707-2.168-6.934-2.168h-8.884V34.58ZM155.243 62.537c-3.467 0-6.597-.794-9.39-2.384-2.745-1.589-4.936-3.78-6.573-6.573-1.589-2.842-2.384-6.117-2.384-9.825 0-3.708.819-6.959 2.456-9.752 1.637-2.842 3.829-5.057 6.573-6.646 2.793-1.59 5.923-2.384 9.391-2.384 3.419 0 6.5.795 9.245 2.384 2.793 1.59 4.984 3.804 6.573 6.646 1.638 2.793 2.456 6.044 2.456 9.752 0 3.708-.818 6.983-2.456 9.825a17.238 17.238 0 0 1-6.573 6.573c-2.793 1.59-5.899 2.384-9.318 2.384Zm0-8.018c2.408 0 4.503-.891 6.284-2.673 1.782-1.83 2.673-4.527 2.673-8.09 0-3.565-.891-6.237-2.673-8.02-1.781-1.83-3.852-2.744-6.211-2.744-2.456 0-4.575.915-6.357 2.745-1.733 1.782-2.6 4.454-2.6 8.018 0 3.564.867 6.26 2.6 8.09 1.782 1.783 3.877 2.674 6.284 2.674ZM177.523 61.67V25.84h8.234l.867 6.718c1.3-2.312 3.058-4.142 5.273-5.49 2.263-1.397 4.912-2.095 7.946-2.095v9.752h-2.601c-2.022 0-3.828.313-5.417.94-1.589.625-2.841 1.709-3.756 3.25-.867 1.541-1.3 3.684-1.3 6.43V61.67h-9.246ZM221.403 61.67c-3.756 0-6.766-.915-9.029-2.745s-3.395-5.08-3.395-9.752V33.569h-6.14v-7.73h6.14l1.083-9.607h8.163v9.608h9.679v7.73h-9.679v15.675c0 1.734.361 2.938 1.083 3.612.771.626 2.071.94 3.901.94h4.478v7.873h-6.284ZM232.23 61.67V25.84h8.235l.867 6.718c1.3-2.312 3.057-4.142 5.273-5.49 2.263-1.397 4.911-2.095 7.945-2.095v9.752h-2.6c-2.023 0-3.829.313-5.418.94-1.589.625-2.841 1.709-3.756 3.25-.866 1.541-1.3 3.684-1.3 6.43V61.67h-9.246ZM269.609 62.537c-3.081 0-5.61-.481-7.584-1.444-1.974-1.012-3.443-2.336-4.406-3.974-.963-1.637-1.445-3.443-1.445-5.418 0-3.323 1.3-6.02 3.901-8.09 2.6-2.071 6.501-3.107 11.701-3.107h9.102v-.866c0-2.457-.699-4.263-2.095-5.419-1.397-1.155-3.13-1.733-5.201-1.733-1.878 0-3.515.457-4.912 1.372-1.396.867-2.263 2.168-2.6 3.901h-9.029c.241-2.6 1.108-4.864 2.6-6.79 1.541-1.927 3.516-3.396 5.923-4.407 2.408-1.06 5.105-1.59 8.09-1.59 5.105 0 9.126 1.277 12.063 3.83 2.938 2.552 4.406 6.164 4.406 10.836V61.67h-7.873l-.867-5.779c-1.059 1.927-2.552 3.516-4.478 4.768-1.878 1.252-4.31 1.878-7.296 1.878Zm2.095-7.224c2.649 0 4.695-.867 6.14-2.6 1.493-1.734 2.432-3.877 2.817-6.43h-7.873c-2.456 0-4.214.458-5.273 1.373-1.06.867-1.589 1.95-1.589 3.25 0 1.397.529 2.481 1.589 3.252 1.059.77 2.456 1.155 4.189 1.155ZM298.874 20.277c-1.685 0-3.082-.505-4.189-1.517-1.06-1.011-1.589-2.287-1.589-3.828s.529-2.793 1.589-3.757c1.107-1.011 2.504-1.517 4.189-1.517 1.686 0 3.058.506 4.117 1.517 1.108.963 1.662 2.216 1.662 3.757 0 1.54-.554 2.817-1.662 3.828-1.059 1.012-2.431 1.517-4.117 1.517Zm-4.623 41.393V25.84h9.246v35.83h-9.246ZM325.499 61.67c-3.756 0-6.766-.915-9.029-2.745s-3.395-5.08-3.395-9.752V33.569h-6.14v-7.73h6.14l1.084-9.607h8.162v9.608H332v7.73h-9.679v15.675c0 1.734.361 2.938 1.083 3.612.771.626 2.071.94 3.901.94h4.478v7.873h-6.284Z"></path>
         </g>
       </svg>
-    </a>
+    </Link>
   );
 };
 
 export const IA = (props: any) => {
   return (
-    <a href="https://archive.org/" target="_blank">
+    <Link href="https://archive.org/" target="_blank">
       <span style={{ ...props.style }}>
         <svg height={props.height} viewBox="0 0 27 30" xmlns="http://www.w3.org/2000/svg">
           <g stroke="none" strokeWidth="1" fill="#FFFFFF" fillRule="evenodd">
@@ -76,7 +78,7 @@ export const IA = (props: any) => {
           </g>
         </svg>
       </span>
-    </a>
+    </Link>
   );
 };
 
@@ -150,7 +152,7 @@ export const QRI = (props: any) => {
 
 export const Zora = (props: any) => {
   return (
-    <a href="https://zora.co/" target="_blank">
+    <Link href="https://zora.co/" target="_blank">
       <svg fill="none" viewBox="0 0 312 69" {...props} className={props.className}>
         <mask id="a" fill="none">
           <path
@@ -172,6 +174,6 @@ export const Zora = (props: any) => {
           />
         </g>
       </svg>
-    </a>
+    </Link>
   );
 };

--- a/components/ProgressCard.tsx
+++ b/components/ProgressCard.tsx
@@ -1,8 +1,8 @@
 import styles from '@components/ProgressCard.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as C from '@common/constants';
+import * as U from '@common/utilities';
+import Link from 'next/link';
 
 const ProgressCard = ({ deal, transfer, chain, marketing, message, contentId }) => {
   let topStyle = { background: null };
@@ -32,27 +32,27 @@ const ProgressCard = ({ deal, transfer, chain, marketing, message, contentId }) 
       <div className={styles.container}>
         <div className={styles.items} style={topStyle}>
           {deal.miner ? (
-            <a className={styles.title} href={minerStatsURL} target="_blank">
+            <Link className={styles.title} href={minerStatsURL} target="_blank">
               {deal.miner}
-            </a>
+            </Link>
           ) : null}
           <div className={styles.plain} style={{ textTransform: 'none' }}>
             {message}
           </div>
           {dealURL ? (
-            <a className={styles.item} href={dealURL}>
+            <Link className={styles.item} href={dealURL}>
               → Status
-            </a>
+            </Link>
           ) : null}
           {proposalURL ? (
-            <a className={styles.item} href={proposalURL}>
+            <Link className={styles.item} href={proposalURL}>
               → Proposal receipt
-            </a>
+            </Link>
           ) : null}
           {receiptURL ? (
-            <a className={styles.item} href={receiptURL}>
+            <Link className={styles.item} href={receiptURL}>
               → Filecoin deal receipt
-            </a>
+            </Link>
           ) : null}
         </div>
       </div>

--- a/components/ResponsiveNavbar.tsx
+++ b/components/ResponsiveNavbar.tsx
@@ -1,9 +1,14 @@
-import EstuarySVG from '@root/components/EstuarySVG';
-import styles from '@components/ResponsiveNavbar.module.scss';
 import { BreakpointEnum, useBreakpoint } from '@common/use-breakpoint';
+import styles from '@components/ResponsiveNavbar.module.scss';
+import EstuarySVG from '@root/components/EstuarySVG';
+import Link from 'next/link';
 import * as React from 'react';
 
-const navItems = [{ name: 'Collaborators', href: '#collaborators' }, { name: 'Performance', href: '#performance' }, { name: 'Deals', href: '#deals' }];
+const navItems = [
+  { name: 'Collaborators', href: '#collaborators' },
+  { name: 'Performance', href: '#performance' },
+  { name: 'Deals', href: '#deals' },
+];
 
 function MobileNav({ navItems }) {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -19,9 +24,9 @@ function MobileNav({ navItems }) {
 
   return (
     <div className={styles.displayMobileNav}>
-      <a className={styles.navBranding} href="https://estuary.tech/" target="_blank">
+      <Link className={styles.navBranding} href="https://estuary.tech/" target="_blank">
         <EstuarySVG height="64px" color="var(--text-white)" className={styles.logo} />
-      </a>
+      </Link>
 
       <div className={isOpen ? styles.activeMobileMenu : styles.mobileMenu} aria-label="Open Navigation" onClick={() => setIsOpen((prev) => !prev)} />
 
@@ -29,9 +34,9 @@ function MobileNav({ navItems }) {
         {navItems.map((item, index) => {
           return (
             <li key={index} className={styles.navItemMobile}>
-              <a className={styles.navLink} href={`${item.href}`}>
+              <Link className={styles.navLink} href={`${item.href}`}>
                 {item.name}
-              </a>
+              </Link>
             </li>
           );
         })}
@@ -43,17 +48,17 @@ function MobileNav({ navItems }) {
 function DesktopNav({ navItems }) {
   return (
     <div className={styles.navbar}>
-      <a className={styles.logoDesktop} href="https://estuary.tech/" target="_blank">
+      <Link className={styles.logoDesktop} href="https://estuary.tech/" target="_blank">
         <EstuarySVG height="64px" color="var(--text-white)" className={styles.logo} />
-      </a>
+      </Link>
 
       <ul className={styles.navMenu}>
         {navItems.map((item, index) => {
           return (
             <li key={index} className={styles.navItem}>
-              <a className={styles.navLink} href={`${item.href}`}>
+              <Link className={styles.navLink} href={`${item.href}`}>
                 {item.name}
-              </a>
+              </Link>
             </li>
           );
         })}

--- a/components/UploadItem.tsx
+++ b/components/UploadItem.tsx
@@ -1,14 +1,15 @@
 import styles from '@components/UploadItem.module.scss';
 
-import * as React from 'react';
-import * as U from '@common/utilities';
 import * as C from '@common/constants';
 import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
 
-import Cookies from 'js-cookie';
-import ProgressBlock from '@components/ProgressBlock';
 import ActionRow from '@components/ActionRow';
 import LoaderSpinner from '@components/LoaderSpinner';
+import ProgressBlock from '@components/ProgressBlock';
+import Cookies from 'js-cookie';
+import Link from 'next/link';
 
 export class PinStatusElement extends React.Component<any> {
   state = { pinned: false, delegates: ['none'] };
@@ -176,14 +177,14 @@ export default class UploadItem extends React.Component<any> {
               {this.props.file.data.name} uploaded to our node!
             </ActionRow>
             <ActionRow>
-              <a href={estuaryRetrievalUrl} target="_blank">
+              <Link href={estuaryRetrievalUrl} target="_blank">
                 {estuaryRetrievalUrl}
-              </a>
+              </Link>
             </ActionRow>
             <ActionRow>
-              <a href={dwebRetrievalUrl} target="_blank">
+              <Link href={dwebRetrievalUrl} target="_blank">
                 {dwebRetrievalUrl}
-              </a>
+              </Link>
             </ActionRow>
             {maybePinStatusElement}
             {this.props.file.estimation ? (

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "estuary-www",
   "version": "0.0.5",
   "engines": {
-    "node": "19.x"
+    "node": "14.x"
 },
   "scripts": {
     "dev": "NEXT_PUBLIC_ESTUARY_API=http://localhost:3004 next dev -p 4444",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.5",
   "engines": {
     "node": ">=16.8"
-},
+  },
   "scripts": {
     "dev": "NEXT_PUBLIC_ESTUARY_API=http://localhost:3004 next dev -p 4444",
     "dev-docker": "NEXT_PUBLIC_ESTUARY_API=${ESTUARY_API:-http://localhost:3004} next dev -p 4444",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "estuary-www",
   "version": "0.0.5",
   "engines": {
-    "node": "14.x"
-  },
+    "node": "19.x"
+},
   "scripts": {
     "dev": "NEXT_PUBLIC_ESTUARY_API=http://localhost:3004 next dev -p 4444",
     "dev-docker": "NEXT_PUBLIC_ESTUARY_API=${ESTUARY_API:-http://localhost:3004} next dev -p 4444",
@@ -30,9 +30,9 @@
     "cors": "^2.8.5",
     "d3": "^5.16.0",
     "js-cookie": "^3.0.1",
-    "next": "^12.2.4",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "next": "^13.0.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-table": "^7.8.0",
     "react-use": "^17.4.0",
     "sass": "1.54.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "estuary-www",
   "version": "0.0.5",
   "engines": {
-    "node": "14.x"
+    "node": ">=16.8"
 },
   "scripts": {
     "dev": "NEXT_PUBLIC_ESTUARY_API=http://localhost:3004 next dev -p 4444",

--- a/pages/admin/content.tsx
+++ b/pages/admin/content.tsx
@@ -12,6 +12,7 @@ import Page from '@components/Page';
 import PageHeader from '@components/PageHeader';
 
 import { H2, P } from '@components/Typography';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -97,18 +98,18 @@ function AdminContentPage(props: any) {
                         <td className={tstyles.td}>{data.name === 'aggregate' ? '/' : data.name}</td>
 
                         <td className={tstyles.tdcta}>
-                          <a className={tstyles.cta} href={`/content/${data.id}`}>
+                          <Link className={tstyles.cta} href={`/content/${data.id}`}>
                             {data.id}
-                          </a>
+                          </Link>
                         </td>
 
                         <td className={tstyles.tdcta}>
-                          <a href={estuaryRetrievalUrl} target="_blank" className={tstyles.cta}>
+                          <Link href={estuaryRetrievalUrl} target="_blank" className={tstyles.cta}>
                             {estuaryRetrievalUrl}
-                          </a>
-                          <a href={dwebRetrievalUrl} target="_blank" className={tstyles.cta}>
+                          </Link>
+                          <Link href={dwebRetrievalUrl} target="_blank" className={tstyles.cta}>
                             {dwebRetrievalUrl}
-                          </a>
+                          </Link>
                         </td>
                         <td className={tstyles.td}>{data.replication} times</td>
                         <td className={tstyles.td}>{U.bytesToSize(data.size)}</td>

--- a/pages/comparisons-web3.tsx
+++ b/pages/comparisons-web3.tsx
@@ -12,6 +12,7 @@ import Navigation from '@components/Navigation';
 import Page from '@components/Page';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 import { H1, H2, P } from '@components/Typography';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -249,24 +250,24 @@ function ComparisonsWeb3Page(props: any) {
           return (
             <div className={S.fam} key={each.addr}>
               <div className={S.fcol4}>
-                <a className={S.flink} href={`/providers/stats/${each.addr}`}>
+                <Link className={S.flink} href={`/providers/stats/${each.addr}`}>
                   {indexValue} {!U.isEmpty(each.name) ? `— ${each.name}` : null}
-                </a>
+                </Link>
               </div>
               <div className={S.fcol4}>
-                <a className={S.flink} href={`/providers/stats/${each.addr}`}>
+                <Link className={S.flink} href={`/providers/stats/${each.addr}`}>
                   ➝ {each.addr}/stats
-                </a>
+                </Link>
               </div>
               <div className={S.fcol4}>
-                <a className={S.flink} href={`/providers/deals/${each.addr}`}>
+                <Link className={S.flink} href={`/providers/deals/${each.addr}`}>
                   ➝ {each.addr}/deals
-                </a>
+                </Link>
               </div>
               <div className={S.fcol4}>
-                <a className={S.flink} href={`/providers/errors/${each.addr}`}>
+                <Link className={S.flink} href={`/providers/errors/${each.addr}`}>
                   ➝ {each.addr}/errors
-                </a>
+                </Link>
               </div>
             </div>
           );
@@ -274,9 +275,9 @@ function ComparisonsWeb3Page(props: any) {
       </footer>
 
       <div className={S.fb}>
-        <a href="https://arg.protocol.ai" target="_blank" className={S.fcta}>
+        <Link href="https://arg.protocol.ai" target="_blank" className={S.fcta}>
           ➝ Built by ARG
-        </a>
+        </Link>
       </div>
     </Page>
   );

--- a/pages/comparisons.tsx
+++ b/pages/comparisons.tsx
@@ -12,6 +12,7 @@ import Navigation from '@components/Navigation';
 import Page from '@components/Page';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 import { H1, H2, P } from '@components/Typography';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -249,24 +250,24 @@ function ComparisonPage(props: any) {
           return (
             <div className={S.fam} key={each.addr}>
               <div className={S.fcol4}>
-                <a className={S.flink} href={`/providers/stats/${each.addr}`}>
+                <Link className={S.flink} href={`/providers/stats/${each.addr}`}>
                   {indexValue} {!U.isEmpty(each.name) ? `— ${each.name}` : null}
-                </a>
+                </Link>
               </div>
               <div className={S.fcol4}>
-                <a className={S.flink} href={`/providers/stats/${each.addr}`}>
+                <Link className={S.flink} href={`/providers/stats/${each.addr}`}>
                   ➝ {each.addr}/stats
-                </a>
+                </Link>
               </div>
               <div className={S.fcol4}>
-                <a className={S.flink} href={`/providers/deals/${each.addr}`}>
+                <Link className={S.flink} href={`/providers/deals/${each.addr}`}>
                   ➝ {each.addr}/deals
-                </a>
+                </Link>
               </div>
               <div className={S.fcol4}>
-                <a className={S.flink} href={`/providers/errors/${each.addr}`}>
+                <Link className={S.flink} href={`/providers/errors/${each.addr}`}>
                   ➝ {each.addr}/errors
-                </a>
+                </Link>
               </div>
             </div>
           );
@@ -274,9 +275,9 @@ function ComparisonPage(props: any) {
       </footer>
 
       <div className={S.fb}>
-        <a href="https://arg.protocol.ai" target="_blank" className={S.fcta}>
+        <Link href="https://arg.protocol.ai" target="_blank" className={S.fcta}>
           ➝ Built by ARG
-        </a>
+        </Link>
       </div>
     </Page>
   );

--- a/pages/deals/[id].tsx
+++ b/pages/deals/[id].tsx
@@ -8,6 +8,7 @@ import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -78,14 +79,14 @@ function DealPage(props: any) {
                   <td className={tstyles.td}>{state.deal.ID}</td>
                   <td className={tstyles.td}>{state.deal.content}</td>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={`/receipts/${state.deal.dealId}`}>
+                    <Link className={tstyles.cta} href={`/receipts/${state.deal.dealId}`}>
                       {state.deal.dealId}
-                    </a>
+                    </Link>
                   </td>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={`/providers/stats/${state.deal.miner}`}>
+                    <Link className={tstyles.cta} href={`/providers/stats/${state.deal.miner}`}>
                       {state.deal.miner}
-                    </a>
+                    </Link>
                   </td>
                 </tr>
               </tbody>
@@ -111,9 +112,9 @@ function DealPage(props: any) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={`/proposals/${state.deal.propCid}`}>
+                    <Link className={tstyles.cta} href={`/proposals/${state.deal.propCid}`}>
                       /proposals/{state.deal.propCid}
-                    </a>
+                    </Link>
                   </td>
                 </tr>
               </tbody>
@@ -128,9 +129,9 @@ function DealPage(props: any) {
                 <tr className={tstyles.tr}>
                   {!U.isEmpty(estuaryRetrievalUrl) ? (
                     <td className={tstyles.tdcta}>
-                      <a className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
+                      <Link className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
                         {estuaryRetrievalUrl}
-                      </a>
+                      </Link>
                     </td>
                   ) : (
                     <td className={tstyles.td}>Does not exist</td>
@@ -148,9 +149,9 @@ function DealPage(props: any) {
                 <tr className={tstyles.tr}>
                   {!U.isEmpty(dwebRetrievalUrl) ? (
                     <td className={tstyles.tdcta}>
-                      <a className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
+                      <Link className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
                         {dwebRetrievalUrl}
-                      </a>
+                      </Link>
                     </td>
                   ) : (
                     <td className={tstyles.td}>Does not exist</td>

--- a/pages/deals/debug.tsx
+++ b/pages/deals/debug.tsx
@@ -8,6 +8,7 @@ import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -72,14 +73,14 @@ function DealDebugPage(props: any) {
                       {U.toDate(log.CreatedAt)}
                     </td>
                     <td className={tstyles.tdcta}>
-                      <a className={tstyles.cta} href={`/content/${log.content}`}>
+                      <Link className={tstyles.cta} href={`/content/${log.content}`}>
                         {log.content}
-                      </a>
+                      </Link>
                     </td>
                     <td className={tstyles.tdcta}>
-                      <a className={tstyles.cta} href={`/providers/stats/${log.miner}`}>
+                      <Link className={tstyles.cta} href={`/providers/stats/${log.miner}`}>
                         {log.miner}
-                      </a>
+                      </Link>
                     </td>
                     <td className={tstyles.td}>{log.phase}</td>
                     <td className={tstyles.td}>{log.message}</td>

--- a/pages/deals/index.tsx
+++ b/pages/deals/index.tsx
@@ -16,6 +16,7 @@ import PageHeader from '@components/PageHeader';
 import ProgressCard from '@components/ProgressCard';
 
 import { H2, P } from '@components/Typography';
+import Link from 'next/link';
 
 const INCREMENT = 100;
 
@@ -102,15 +103,15 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
             <td className={tstyles.td}>{name}</td>
 
             <td className={tstyles.tdcta}>
-              <a className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
+              <Link className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
                 {estuaryRetrievalUrl}
-              </a>
+              </Link>
             </td>
 
             <td className={tstyles.tdcta}>
-              <a className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
+              <Link className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
                 {dwebRetrievalUrl}
-              </a>
+              </Link>
             </td>
 
             <td className={tstyles.td}>{id}</td>
@@ -126,9 +127,9 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
       ) : null}
       <div className={styles.titleSection}>
         Estuary made {dealElements.length} {U.pluralize('attempt', dealElements.length)}&nbsp;
-        <a href={dealErrorURL} style={{ color: `var(--main-text)` }} target="_blank">
+        <Link href={dealErrorURL} style={{ color: `var(--main-text)` }} target="_blank">
           (view logs)
-        </a>
+        </Link>
         &nbsp;
         {failureCount > 0 ? (
           <span style={{ color: `var(--main-text)`, textDecoration: 'underline', cursor: 'pointer' }} onClick={() => setState({ ...state, showFailures: !state.showFailures })}>

--- a/pages/deals/index.tsx
+++ b/pages/deals/index.tsx
@@ -103,15 +103,19 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
             <td className={tstyles.td}>{name}</td>
 
             <td className={tstyles.tdcta}>
-              <Link className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
-                {estuaryRetrievalUrl}
-              </Link>
+              {estuaryRetrievalUrl ? (
+                <Link className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
+                  {estuaryRetrievalUrl}
+                </Link>
+              ) : null}
             </td>
 
             <td className={tstyles.tdcta}>
-              <Link className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
-                {dwebRetrievalUrl}
-              </Link>
+              {dwebRetrievalUrl ? (
+                <Link className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
+                  {dwebRetrievalUrl}
+                </Link>
+              ) : null}
             </td>
 
             <td className={tstyles.td}>{id}</td>
@@ -127,9 +131,11 @@ export const ContentCard = ({ content, deals, id, root, failuresCount, viewer })
       ) : null}
       <div className={styles.titleSection}>
         Estuary made {dealElements.length} {U.pluralize('attempt', dealElements.length)}&nbsp;
-        <Link href={dealErrorURL} style={{ color: `var(--main-text)` }} target="_blank">
-          (view logs)
-        </Link>
+        {dealErrorURL ? (
+          <Link href={dealErrorURL} style={{ color: `var(--main-text)` }} target="_blank">
+            (view logs)
+          </Link>
+        ) : null}
         &nbsp;
         {failureCount > 0 ? (
           <span style={{ color: `var(--main-text)`, textDecoration: 'underline', cursor: 'pointer' }} onClick={() => setState({ ...state, showFailures: !state.showFailures })}>

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -11,6 +11,7 @@ import Page from '@components/Page';
 
 import Footer from '@root/components/Footer';
 import ResponsiveNavbar from '@root/components/ResponsiveNavbar';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -221,84 +222,84 @@ function EcosystemPage(props: any) {
                 </div>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://archive.org/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://archive.org/" target="_blank">
                   <img height="50vh" src="https://user-images.githubusercontent.com/28320272/203411654-adf169fb-0493-446a-8393-19d932d93618.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://kodadot.xyz/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://kodadot.xyz/" target="_blank">
                   <img height="60vh" src="https://user-images.githubusercontent.com/28320272/203411306-01912ea7-9503-4d6a-9501-e243c7123d89.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://wallet.glif.io/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://wallet.glif.io/" target="_blank">
                   <img height="80vh" src="https://user-images.githubusercontent.com/28320272/203406224-c17a8fd5-fae9-49a0-97c9-3ebf4e704d4f.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://chainsafe.io/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://chainsafe.io/" target="_blank">
                   <img height="50vh" src="https://user-images.githubusercontent.com/28320272/202939033-a899fadf-5438-44d4-aa09-1c76e660072c.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://opendata.cityofnewyork.us/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://opendata.cityofnewyork.us/" target="_blank">
                   <img height="80vh" src="https://user-images.githubusercontent.com/28320272/203404943-0d4d5e2f-195b-4b1e-ab2b-e88fae6a3aac.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://app.gala.games/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://app.gala.games/" target="_blank">
                   <img height="50vh" src="https://user-images.githubusercontent.com/28320272/202942649-b7237e6a-4c38-487a-b167-07a3833917a5.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://www.vividlabs.com/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://www.vividlabs.com/" target="_blank">
                   <img height="50vh" src="https://user-images.githubusercontent.com/310223/156037345-f93054de-d222-47e9-9653-cd957fc0fcc5.svg" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://w3bmint.xyz/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://w3bmint.xyz/" target="_blank">
                   <img height="50vh" src="https://user-images.githubusercontent.com/28320272/203404877-791e53c6-7ec6-48b6-960a-f65c4aa46e29.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://sxxfuture.com/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://sxxfuture.com/" target="_blank">
                   <img height="35vh" src="https://user-images.githubusercontent.com/28320272/204052332-56be823b-b058-4232-96a5-ef3d569dcc56.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://gitopia.com/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://gitopia.com/" target="_blank">
                   <img height="50vh" src="https://user-images.githubusercontent.com/28320272/202940154-8c54b568-70cd-4063-b21d-38aee052a063.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://hashaxis.com/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://hashaxis.com/" target="_blank">
                   <img height="50vh" src="https://user-images.githubusercontent.com/28320272/202942456-d921ed27-c0c1-4d9e-98ae-f0189e740bc1.svg" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://www.labdao.xyz/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://www.labdao.xyz/" target="_blank">
                   <img height="45vh" src="https://user-images.githubusercontent.com/28320272/202940852-dda0b5d6-7bb4-4ea3-9c86-ec6bc6286104.svg" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://green.filecoin.io/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://green.filecoin.io/" target="_blank">
                   <img height="70vh" src="https://user-images.githubusercontent.com/28320272/202937974-6d191fae-264f-40b0-b18e-3071b8009802.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://www.cancerimagingarchive.net/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://www.cancerimagingarchive.net/" target="_blank">
                   <img height="50vh" src="https://user-images.githubusercontent.com/28320272/202939283-c78969dd-2f06-42dd-8823-cb6d23ff3818.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://opsci.io/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://opsci.io/" target="_blank">
                   <img height="50vh" src="https://user-images.githubusercontent.com/28320272/202937956-0c12b60d-8a38-4e9b-9749-3420598276f8.png" />
-                </a>
+                </Link>
               </div>
               <div className={S.column}>
-                <a className={S.ecosystemLogoBox} href="https://www.bacalhau.org/" target="_blank">
+                <Link className={S.ecosystemLogoBox} href="https://www.bacalhau.org/" target="_blank">
                   <img height="50vh" src="https://user-images.githubusercontent.com/28320272/202938869-73f5fcc1-7d0c-4e4c-b2d0-bd1d62ceac39.png" />
-                </a>
+                </Link>
               </div>
             </div>
           </div>
@@ -478,24 +479,24 @@ function EcosystemPage(props: any) {
             return (
               <div className={S.fam} key={each.addr}>
                 <div className={S.fcol4}>
-                  <a className={S.flink} href={`/providers/stats/${each.addr}`}>
+                  <Link className={S.flink} href={`/providers/stats/${each.addr}`}>
                     {indexValue} {!U.isEmpty(each.name) ? `— ${each.name}` : null}
-                  </a>
+                  </Link>
                 </div>
                 <div className={S.fcol4}>
-                  <a className={S.flink} href={`/providers/stats/${each.addr}`}>
+                  <Link className={S.flink} href={`/providers/stats/${each.addr}`}>
                     ➝ {each.addr}/stats
-                  </a>
+                  </Link>
                 </div>
                 <div className={S.fcol4}>
-                  <a className={S.flink} href={`/providers/deals/${each.addr}`}>
+                  <Link className={S.flink} href={`/providers/deals/${each.addr}`}>
                     ➝ {each.addr}/deals
-                  </a>
+                  </Link>
                 </div>
                 <div className={S.fcol4}>
-                  <a className={S.flink} href={`/providers/errors/${each.addr}`}>
+                  <Link className={S.flink} href={`/providers/errors/${each.addr}`}>
                     ➝ {each.addr}/errors
-                  </a>
+                  </Link>
                 </div>
               </div>
             );

--- a/pages/errors/[id].tsx
+++ b/pages/errors/[id].tsx
@@ -8,6 +8,7 @@ import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -77,9 +78,9 @@ function DealErrorPage(props: any) {
                     </td>
                     <td className={tstyles.td}>{log.content}</td>
                     <td className={tstyles.tdcta}>
-                      <a className={tstyles.cta} href={`/providers/stats/${log.miner}`}>
+                      <Link className={tstyles.cta} href={`/providers/stats/${log.miner}`}>
                         {log.miner}
-                      </a>
+                      </Link>
                     </td>
                     <td className={tstyles.td}>{log.deal_uuid}</td>
                     <td className={tstyles.td}>{log.phase}</td>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import * as C from '@common/constants';
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
+import Link from 'next/link';
 
 const curl = `curl \n-X POST https://api.estuary.tech/content/add \n-H "Authorization: Bearer YOUR_API_KEY" \n-H "Accept: application/json" \n-H "Content-Type: multipart/form-data" \n-F "data=@PATH_TO_FILE"`;
 
@@ -132,13 +133,13 @@ function IndexPage(props: any) {
       <div className={styles.heading}>
         <h1 className={styles.h1}>
           A reliable way to upload public data onto{' '}
-          <a className={styles.link} href="https://filecoin.io" target="_blank">
+          <Link className={styles.link} href="https://filecoin.io" target="_blank">
             Filecoin
-          </a>{' '}
+          </Link>{' '}
           and pin it to{' '}
-          <a className={styles.link} href="https://ipfs.io" target="_blank">
+          <Link className={styles.link} href="https://ipfs.io" target="_blank">
             IPFS
-          </a>
+          </Link>
           .
         </h1>
         <p className={styles.caption}>
@@ -224,13 +225,13 @@ function IndexPage(props: any) {
           This node makes storage deals against <b>{state.miners.length} decentralized storage providers</b> and growing. Storage providers who are on our main Estuary Node's list
           have graciously accepted all data as it comes their way, which really helps us test and improve the Filecoin network. When this node successfully stores data, any user of
           this node can verify their{' '}
-          <a href="https://proto.school/anatomy-of-a-cid" className={styles.link} target="_blank">
+          <Link href="https://proto.school/anatomy-of-a-cid" className={styles.link} target="_blank">
             CID
-          </a>{' '}
+          </Link>{' '}
           is on chain by visiting the{' '}
-          <a href="/verify-cid?cid=QmVrrF7DTnbqKvWR7P7ihJKp4N5fKmBX29m5CHbW9WLep9" className={styles.link}>
+          <Link href="/verify-cid?cid=QmVrrF7DTnbqKvWR7P7ihJKp4N5fKmBX29m5CHbW9WLep9" className={styles.link}>
             verify page
-          </a>
+          </Link>
           .
         </h2>
       </div>
@@ -245,9 +246,9 @@ function IndexPage(props: any) {
             </div>
 
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://docs.estuary.tech" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://docs.estuary.tech" target="_blank">
                 Read docs ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -261,9 +262,9 @@ function IndexPage(props: any) {
             </div>
 
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://github.com/application-research/estuary" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://github.com/application-research/estuary" target="_blank">
                 View source ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -277,9 +278,9 @@ function IndexPage(props: any) {
             </div>
 
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="/ecosystem" target="_blank">
+              <Link className={styles.actionButtonLink} href="/ecosystem" target="_blank">
                 View dashboard ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -293,9 +294,9 @@ function IndexPage(props: any) {
             </div>
 
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://www.twitter.com/aresearchgroup" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://www.twitter.com/aresearchgroup" target="_blank">
                 Follow on Twitter ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -333,9 +334,9 @@ function IndexPage(props: any) {
             </div>
 
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://dweb.link/ipfs/QmSX2wCbAeMVXB3Gdfd23MnLW5wxpzE41dG7W1S4d5RXPi" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://dweb.link/ipfs/QmSX2wCbAeMVXB3Gdfd23MnLW5wxpzE41dG7W1S4d5RXPi" target="_blank">
                 Try it ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -348,9 +349,9 @@ function IndexPage(props: any) {
               <p className={styles.p}>Check our FAQ for answers to your questions</p>
             </div>
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://docs.estuary.tech/faq" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://docs.estuary.tech/faq" target="_blank">
                 Read FAQ ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -363,9 +364,9 @@ function IndexPage(props: any) {
               <p className={styles.p}>Do you have questions about Estuary? Ask your question using this form, everyone on the team will see it.</p>
             </div>
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://docs.estuary.tech/feedback" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://docs.estuary.tech/feedback" target="_blank">
                 Give feedback ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -378,9 +379,9 @@ function IndexPage(props: any) {
               <p className={styles.p}>Check out our repositories on GitHub to contribute to our tools to use IPFS, Filecoin and Libp2p.</p>
             </div>
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://github.com/application-research" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://github.com/application-research" target="_blank">
                 GitHub ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -393,9 +394,9 @@ function IndexPage(props: any) {
               <p className={styles.p}>Filecoin is an open-source cloud storage marketplace, protocol, and incentive layer.</p>
             </div>
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://filecoin.io" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://filecoin.io" target="_blank">
                 Learn more ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -408,9 +409,9 @@ function IndexPage(props: any) {
               <p className={styles.p}>This project is maintained by the Application Research Group.</p>
             </div>
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://arg.protocol.ai" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://arg.protocol.ai" target="_blank">
                 Learn more ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -446,9 +447,9 @@ function IndexPage(props: any) {
               <p className={styles.p}>This website is open source. You can make contributions here.</p>
             </div>
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://github.com/application-research/estuary-www" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://github.com/application-research/estuary-www" target="_blank">
                 View source ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -461,9 +462,9 @@ function IndexPage(props: any) {
               <p className={styles.p}>Want to follow a step by step guide to learn how to use Estuary? Try our tutorial.</p>
             </div>
             <div className={styles.action}>
-              <a className={styles.actionButtonLink} href="https://docs.estuary.tech/tutorial-get-an-api-key" target="_blank">
+              <Link className={styles.actionButtonLink} href="https://docs.estuary.tech/tutorial-get-an-api-key" target="_blank">
                 View tutorial ➝
-              </a>
+              </Link>
             </div>
           </div>
         </div>

--- a/pages/proposals/[cid].tsx
+++ b/pages/proposals/[cid].tsx
@@ -8,6 +8,7 @@ import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -71,9 +72,9 @@ function ProposalPage(props: any) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
+                    <Link className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
                       {estuaryRetrievalUrl}
-                    </a>
+                    </Link>
                   </td>
                 </tr>
               </tbody>
@@ -87,9 +88,9 @@ function ProposalPage(props: any) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
+                    <Link className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
                       {dwebRetrievalUrl}
-                    </a>
+                    </Link>
                   </td>
                 </tr>
               </tbody>
@@ -167,9 +168,9 @@ function ProposalPage(props: any) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={`/providers/stats/${state.deal.Provider}`}>
+                    <Link className={tstyles.cta} href={`/providers/stats/${state.deal.Provider}`}>
                       {state.deal.Provider}
-                    </a>
+                    </Link>
                   </td>
                 </tr>
               </tbody>

--- a/pages/providers/deals/[id].tsx
+++ b/pages/providers/deals/[id].tsx
@@ -8,6 +8,7 @@ import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -70,14 +71,14 @@ function MinerDealsPage(props: any) {
                     <tr key={log.ID} className={tstyles.tr} style={style}>
                       <td className={tstyles.td}>{U.toDate(log.created_at)}</td>
                       <td className={tstyles.tdcta}>
-                        <a className={tstyles.cta} href={`/content/${log.content}`}>
+                        <Link className={tstyles.cta} href={`/content/${log.content}`}>
                           {log.content}
-                        </a>
+                        </Link>
                       </td>
                       <td className={tstyles.tdcta}>
-                        <a className={tstyles.cta} href={`/providers/stats/${log.miner}`}>
+                        <Link className={tstyles.cta} href={`/providers/stats/${log.miner}`}>
                           {log.miner}
-                        </a>
+                        </Link>
                       </td>
                       <td className={tstyles.td}>{log.failed ? '--' : log.dealId > 0 ? log.dealId : 'in-progress'}</td>
                       <td className={tstyles.td}>{log.propCid}</td>

--- a/pages/providers/errors/[id].tsx
+++ b/pages/providers/errors/[id].tsx
@@ -8,6 +8,7 @@ import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -66,9 +67,9 @@ function MinerErrorPage(props: any) {
                     <td className={tstyles.td}>{U.toDate(log.CreatedAt)}</td>
                     <td className={tstyles.td}>{log.content}</td>
                     <td className={tstyles.tdcta}>
-                      <a className={tstyles.cta} href={`/providers/stats/${log.miner}`}>
+                      <Link className={tstyles.cta} href={`/providers/stats/${log.miner}`}>
                         {log.miner}
-                      </a>
+                      </Link>
                     </td>
                     <td className={tstyles.td}>{log.deal_uuid}</td>
                     <td className={tstyles.td}>{log.phase}</td>

--- a/pages/receipts/[id].tsx
+++ b/pages/receipts/[id].tsx
@@ -8,6 +8,7 @@ import AuthenticatedLayout from '@components/AuthenticatedLayout';
 import AuthenticatedSidebar from '@components/AuthenticatedSidebar';
 import Navigation from '@components/Navigation';
 import Page from '@components/Page';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -71,9 +72,9 @@ function ReceiptPage(props) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
+                    <Link className={tstyles.cta} href={estuaryRetrievalUrl} target="_blank">
                       {estuaryRetrievalUrl}
-                    </a>
+                    </Link>
                   </td>
                 </tr>
               </tbody>
@@ -87,9 +88,9 @@ function ReceiptPage(props) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
+                    <Link className={tstyles.cta} href={dwebRetrievalUrl} target="_blank">
                       {dwebRetrievalUrl}
-                    </a>
+                    </Link>
                   </td>
                 </tr>
               </tbody>
@@ -179,9 +180,9 @@ function ReceiptPage(props) {
 
                 <tr className={tstyles.tr}>
                   <td className={tstyles.tdcta}>
-                    <a className={tstyles.cta} href={`/providers/stats/${state.deal.Provider}`}>
+                    <Link className={tstyles.cta} href={`/providers/stats/${state.deal.Provider}`}>
                       {state.deal.Provider}
-                    </a>
+                    </Link>
                   </td>
                 </tr>
               </tbody>

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -15,6 +15,7 @@ import Page from '@components/Page';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 
 import { H2, H3, H4, P } from '@components/Typography';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -155,7 +156,7 @@ function SettingsPage(props: any) {
               <H4 style={{ marginTop: 24 }}>Fission Filecoin address</H4>
               <Input style={{ marginTop: 8 }} readOnly value={address ? address : ''} />
               <aside className={styles.formAside}>
-                This address is provided to your account when you <strong>sign in with Fission</strong>. To learn more visit <a href="/fission">Fission's website</a>.
+                This address is provided to your account when you <strong>sign in with Fission</strong>. To learn more visit <Link href="/fission">Fission's website</Link>.
               </aside>
             </React.Fragment>
           ) : null}
@@ -176,8 +177,8 @@ function SettingsPage(props: any) {
           <H4 style={{ marginTop: 24 }}>Max staging wait (nanoseconds)</H4>
           <Input style={{ marginTop: 8 }} readOnly value={viewer.settings.maxStagingWait} />
           <aside className={styles.formAside}>
-            The amount of time Estuary waits before making deals for a <a href="/staging">staging zone</a>. Currently Estuary waits {U.nanoToHours(viewer.settings.maxStagingWait)}{' '}
-            hours.
+            The amount of time Estuary waits before making deals for a <Link href="/staging">staging zone</Link>. Currently Estuary waits{' '}
+            {U.nanoToHours(viewer.settings.maxStagingWait)} hours.
           </aside>
 
           <H4 style={{ marginTop: 24 }}>Staging threshold (bytes)</H4>

--- a/pages/sign-up.tsx
+++ b/pages/sign-up.tsx
@@ -13,6 +13,7 @@ import SingleColumnLayout from '@components/SingleColumnLayout';
 import Cookies from 'js-cookie';
 
 import { H2, H3, H4, P } from '@components/Typography';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -197,9 +198,9 @@ function SignUpPage(props: any) {
         />
         <aside className={styles.formAside}>
           Need an invite key?{' '}
-          <a href="https://docs.estuary.tech" target="_blank">
+          <Link href="https://docs.estuary.tech" target="_blank">
             Learn how to get one.
-          </a>
+          </Link>
           .
         </aside>
 
@@ -240,9 +241,9 @@ function SignUpPage(props: any) {
         </div>
         <aside className={styles.formAside} style={{ marginTop: 8, display: 'block' }}>
           By creating an account or by using Estuary you unconditionally agree to our{' '}
-          <a href="https://docs.estuary.tech/terms" target="_blank">
+          <Link href="https://docs.estuary.tech/terms" target="_blank">
             Terms of Service
-          </a>
+          </Link>
           .
         </aside>
       </SingleColumnLayout>

--- a/pages/staging/index.tsx
+++ b/pages/staging/index.tsx
@@ -13,6 +13,7 @@ import Page from '@components/Page';
 import PageHeader from '@components/PageHeader';
 
 import { H2, P } from '@components/Typography';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -83,9 +84,9 @@ function StagingPage(props) {
                 return (
                   <tr className={tstyles.tr}>
                     <td className={tstyles.td}>
-                      <a href={zoneHref} className={tstyles.cta}>
-                        {zone.id}
-                      </a>
+                      <Link href={zoneHref} className={tstyles.cta}>
+                        {zone.id}{' '}
+                      </Link>
                     </td>
                     <td className={tstyles.td}>{U.toDate(zone.CreatedAt)}</td>
                     <td className={tstyles.td}>{U.bytesToSize(zone.curSize)}</td>

--- a/pages/upload-cid.tsx
+++ b/pages/upload-cid.tsx
@@ -14,6 +14,7 @@ import Page from '@components/Page';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 
 import { H2, H4, P } from '@components/Typography';
+import Link from 'next/link';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -77,15 +78,15 @@ function UploadCIDPage(props: any) {
                 Check your CID
                 <div>
                   <H4>Estuary retrieval url</H4>
-                  <a href={estuaryRetrievalUrl} target="_blank">
+                  <Link href={estuaryRetrievalUrl} target="_blank">
                     {estuaryRetrievalUrl}
-                  </a>
+                  </Link>
                 </div>
                 <div>
                   <H4>Dweb retrieval url</H4>
-                  <a href={dwebRetrievalUrl} target="_blank">
+                  <Link href={dwebRetrievalUrl} target="_blank">
                     {dwebRetrievalUrl}
-                  </a>
+                  </Link>
                 </div>
               </aside>
             )}

--- a/pages/verify-cid.tsx
+++ b/pages/verify-cid.tsx
@@ -14,6 +14,7 @@ import RetrievalCommands from '@components/RetrievalCommands';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 import StatRow from '@components/StatRow';
 import { CodeBlock, H1, H2, H3, P } from '@components/Typography';
+import Link from 'next/link';
 
 // NOTE(jim): test CIDs
 // QmYNSTn2XrxDsF3qFdeYKSxjodsbswJV3mj1ffEJZa2jQL
@@ -62,7 +63,7 @@ const onCheckCID = async (state, setState, host) => {
   const response = await R.get(`/public/by-cid/${state.cid}`, host);
 
   if (response.error) {
-    return setState({ ...state, working: false, data: {error: response.error} });
+    return setState({ ...state, working: false, data: { error: response.error } });
   }
 
   if (history.pushState) {
@@ -179,7 +180,9 @@ function VerifyCIDPage(props: any) {
       <div className={S.scustom} style={{ marginTop: 48 }}>
         <H3>Request Error</H3>
         <P style={{ marginTop: 8 }}>There was an error verifying this CID</P>
-        <CodeBlock style={{ marginTop: 8, fontSize: 10}}>{state.data.error.code}: {state.data.error.details}</CodeBlock>
+        <CodeBlock style={{ marginTop: 8, fontSize: 10 }}>
+          {state.data.error.code}: {state.data.error.details}
+        </CodeBlock>
       </div>
     );
   }
@@ -214,14 +217,14 @@ function VerifyCIDPage(props: any) {
               {statusElement}
               <StatRow title="CID">{state.data.content.cid}</StatRow>
               <StatRow title="Estuary retrieval url">
-                <a href={estuaryRetrievalUrl} target="_blank">
+                <Link href={estuaryRetrievalUrl} target="_blank">
                   {estuaryRetrievalUrl}
-                </a>
+                </Link>
               </StatRow>
               <StatRow title="Dweb retrieval url">
-                <a href={dwebRetrievalUrl} target="_blank">
+                <Link href={dwebRetrievalUrl} target="_blank">
                   {dwebRetrievalUrl}
-                </a>
+                </Link>
               </StatRow>
               <StatRow title="Estuary Node ID">{state.data.content.id}</StatRow>
               <StatRow title="Size">
@@ -235,14 +238,14 @@ function VerifyCIDPage(props: any) {
               {statusElement}
 
               <StatRow title="Estuary retrieval url">
-                <a href={estuaryRetrievalUrl} target="_blank">
+                <Link href={estuaryRetrievalUrl} target="_blank">
                   {estuaryRetrievalUrl}
-                </a>
+                </Link>
               </StatRow>
               <StatRow title="Dweb retrieval url">
-                <a href={dwebRetrievalUrl} target="_blank">
+                <Link href={dwebRetrievalUrl} target="_blank">
                   {dwebRetrievalUrl}
-                </a>
+                </Link>
               </StatRow>
             </React.Fragment>
           )}
@@ -261,16 +264,16 @@ function VerifyCIDPage(props: any) {
                   <div key={d.ID} style={{ marginTop: 16 }}>
                     <StatRow title="Provider">
                       {d.miner}{' '}
-                      <a href={`/providers/stats/${d.miner}`} target="_blank">
+                      <Link href={`/providers/stats/${d.miner}`} target="_blank">
                         (view provider)
-                      </a>
+                      </Link>
                     </StatRow>
                     <StatRow title="Success date">{U.toDate(d.sealedAt)}</StatRow>
                     <StatRow title="Retrieval deal ID">
                       {d.dealId}{' '}
-                      <a href={`/receipts/${d.dealId}`} target="_blank">
+                      <Link href={`/receipts/${d.dealId}`} target="_blank">
                         (view receipt)
-                      </a>
+                      </Link>
                     </StatRow>
                     <StatRow title="CLI retrieval">
                       <RetrievalCommands
@@ -320,9 +323,9 @@ function VerifyCIDPage(props: any) {
       </div>
 
       <div className={S.fb} style={{ marginTop: 188 }}>
-        <a href="https://arg.protocol.ai" target="_blank" className={S.fcta}>
+        <Link href="https://arg.protocol.ai" target="_blank" className={S.fcta}>
           ➝ Built by ARG
-        </a>
+        </Link>
       </div>
     </Page>
   );


### PR DESCRIPTION
1. Bump next and related packages according to https://beta.nextjs.org/docs/upgrade-guide#nextjs-version
2. Replace `<a>` tags with `<Link>` to pickup prefetching benefits from next 13: https://beta.nextjs.org/docs/routing/linking-and-navigating#link-component
3. check for null hrefs since they break `<Link>`

This results in ~30% faster loading of estuary-www pages visited through a link within estuary-www.

---

screen recording demoing jumping between links on a production build:

https://user-images.githubusercontent.com/2850013/208543818-b95c4f42-adb4-48ef-9b0a-92786b0ebb51.mov

