### PR TITLE
feat: add success / fail rates

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,18 +1,18 @@
 {
-   "printWidth":180,
-   "tabWidth":2,
-   "useTabs":false,
-   "semi":true,
-   "singleQuote":true,
-   "trailingComma":"es5",
-   "bracketSpacing":true,
-   "jsxBracketSameLine":false,
-   "arrowParens":"always",
-   "requirePragma":false,
-   "insertPragma":false,
-   "proseWrap":"preserve",
-   "parser":"babel",
-   "overrides": [
+  "printWidth": 180,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "arrowParens": "always",
+  "requirePragma": false,
+  "insertPragma": false,
+  "proseWrap": "preserve",
+  "parser": "babel",
+  "overrides": [
     {
       "files": "*.js",
       "options": {

--- a/components/ProgressBar.module.scss
+++ b/components/ProgressBar.module.scss
@@ -1,0 +1,38 @@
+.containerStyles {
+  height: 28px;
+  width: 100%;
+  background-color: var(--text-white);
+}
+
+.fillerStyles {
+  height: 100%;
+  background-color: var(--color-green);
+  border-radius: inherit;
+  text-align: right;
+  transition: width 1s ease-in-out;
+  height: 28px;
+  line-height: 28px;
+}
+
+.labelStyles {
+  padding: 5;
+  color: var(--color-green-shadow);
+  font-family: Mono;
+  font-weight: bold;
+  display: inline-block;
+  vertical-align: middle;
+  line-height: normal;
+  padding-right: 8px;
+  font-size: 16px;
+}
+
+.labelTitle {
+  color: var(--text-white);
+  margin-top: 12px;
+  font-family: Mono;
+  font-size: 20px;
+
+  @media (max-width: 768px) {
+    font-size: 16px;
+  }
+}

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -1,0 +1,22 @@
+import styles from '@components/ProgressBar.module.scss';
+
+export default function ProgressBar(props) {
+  const { bgcolor, completed } = props;
+  const completedRounded = Math.round(completed * 100) / 100;
+
+  const notCompleted = Math.round((100 - completed) * 100) / 100;
+  return (
+    <div style={{ display: 'grid', rowGap: '12px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <p className={styles.labelTitle}>Success: {`${completedRounded}%`} </p>
+        <p className={styles.labelTitle}>Failure: {`${notCompleted}%`} </p>
+      </div>
+
+      <div className={styles.containerStyles}>
+        <div className={styles.fillerStyles} style={{ width: `${completed}%` }}>
+          <span className={styles.labelStyles}>{`${completedRounded}%`}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/global.scss
+++ b/global.scss
@@ -117,13 +117,14 @@ img {
 }
 
 html,
-body { 
+body {
   --line-height: 1.5;
- 
-  --border-white:#ffffff;
+
+  --border-white: #ffffff;
   --border-fainted-white: rgba(255, 255, 255, 0.5);
 
-  --color-green:  #76FF01;
+  --color-green: #76ff01;
+  --color-green-shadow: #4fa406;
   --main-background: rgba(246, 246, 246, 1);
   --main-background-white: #ffffff;
   --main-background-foreground: rgba(240, 240, 240, 1);

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -49,6 +49,7 @@ function EcosystemPage(props: any) {
     totalStorageMiner: 0,
     totalObjectsRef: 0,
     environmentDevices: null,
+    successFailureRates: null,
   });
   const [graph, setGraph] = React.useState({ data: null, dealsSealedBytes: 0 });
 
@@ -135,16 +136,18 @@ function EcosystemPage(props: any) {
 
   React.useEffect(() => {
     const run = async () => {
+      const successFailRateStats = await R.get('/api/v1/stats/storage-rates', C.api.metricsHost)
       const miners = await R.get('/public/miners', props.api);
       const stats = await R.get('/api/v1/stats/info', C.api.metricsHost);
       const environment = await R.post('/api/v1/environment/equinix/list/usages', staticEnvironmentPayload, C.api.metricsHost);
 
       if ((miners && miners.error) || (stats && stats.error)) {
-        return setState({ ...state, miners: [], totalStorage: 0, totalFilesStored: 0, totalObjectsRef: 0, environmentDevices: environment });
+        return setState({ ...state, miners: [], totalStorage: 0, totalFilesStored: 0, totalObjectsRef: 0, environmentDevices: environment, successFailureRates: successFailRateStats });
       }
-      setState({ ...state, miners, ...stats, environmentDevices: environment });
+      setState({ ...state, miners, ...stats, environmentDevices: environment, successFailureRates: successFailRateStats });
     };
     console.log(state.environmentDevices);
+    console.log(state.successFailureRates);
     run();
   }, []);
 
@@ -407,7 +410,6 @@ function EcosystemPage(props: any) {
             </div>
           </div>
           <div className={S.ecosystemPerformance} style={{ marginTop: '40px' }}>
-            {/*{state.environmentDevices}*/}
             {state.environmentDevices != undefined && state.environmentDevices['device_usages'] != undefined
               ? state.environmentDevices['device_usages'].map((device) => {
                   return (
@@ -438,6 +440,16 @@ function EcosystemPage(props: any) {
             </div>
           </div>
         </div>
+
+        <h2 id="deals" className={S.ecosystemH2} style={{ paddingBottom: '0px' }}>
+          Deals Success and Failure rates
+        </h2>
+        {state.successFailureRates != undefined ? (
+          <div className={S.ecosystemStatValue}>
+            <div>{state.successFailureRates['dealSuccessRate']}</div>
+            <div>{state.successFailureRates['dealFailureRate']}</div>
+          </div>
+        ) : null }
 
         <h2 id="deals" className={S.ecosystemH2} style={{ paddingBottom: '0px' }}>
           Deals

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -442,12 +442,27 @@ function EcosystemPage(props: any) {
         </div>
 
         <h2 id="deals" className={S.ecosystemH2} style={{ paddingBottom: '0px' }}>
-          Deals Success and Failure rates
+          Deal rates
         </h2>
         {state.successFailureRates != undefined ? (
-          <div className={S.ecosystemStatValue}>
-            <div>{state.successFailureRates['dealSuccessRate']}</div>
-            <div>{state.successFailureRates['dealFailureRate']}</div>
+          <div className={S.ecosystemPerformance} style={{ marginTop: '0px' }}>
+            <div className={S.ecosystemShuttleData}>
+              <div className={S.ecosystemSection}>
+                <div className={S.ecosystemStatCard}>
+                  <div className={S.ecosystemStatValue} style={{fontSize: "30px", color: "#76ff01"}}>{state.successFailureRates['dealSuccessRate']}</div>
+                  <div className={S.ecosystemStatLabel}>Success Rate</div>
+                </div>
+              </div>
+            </div>
+            <div className={S.ecosystemShuttleData}>
+
+              <div className={S.ecosystemSection}>
+                <div className={S.ecosystemStatCard}>
+                  <div className={S.ecosystemStatValue} style={{ fontSize: "30px", color: "#cb1b3f"}}>{state.successFailureRates['dealFailureRate']}</div>
+                  <div className={S.ecosystemStatLabel} style={{ color: "#cb1b3f"}}>Failure Rate</div>
+                </div>
+              </div>
+            </div>
           </div>
         ) : null }
 

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -11,6 +11,7 @@ import Page from '@components/Page';
 
 import Footer from '@root/components/Footer';
 import ResponsiveNavbar from '@root/components/ResponsiveNavbar';
+import ProgressBar from '@root/components/ProgressBar';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -136,13 +137,21 @@ function EcosystemPage(props: any) {
 
   React.useEffect(() => {
     const run = async () => {
-      const successFailRateStats = await R.get('/api/v1/stats/storage-rates', C.api.metricsHost)
+      const successFailRateStats = await R.get('/api/v1/stats/storage-rates', C.api.metricsHost);
       const miners = await R.get('/public/miners', props.api);
       const stats = await R.get('/api/v1/stats/info', C.api.metricsHost);
       const environment = await R.post('/api/v1/environment/equinix/list/usages', staticEnvironmentPayload, C.api.metricsHost);
 
       if ((miners && miners.error) || (stats && stats.error)) {
-        return setState({ ...state, miners: [], totalStorage: 0, totalFilesStored: 0, totalObjectsRef: 0, environmentDevices: environment, successFailureRates: successFailRateStats });
+        return setState({
+          ...state,
+          miners: [],
+          totalStorage: 0,
+          totalFilesStored: 0,
+          totalObjectsRef: 0,
+          environmentDevices: environment,
+          successFailureRates: successFailRateStats,
+        });
       }
       setState({ ...state, miners, ...stats, environmentDevices: environment, successFailureRates: successFailRateStats });
     };
@@ -326,7 +335,6 @@ function EcosystemPage(props: any) {
             </div>
           </div>
         </div>
-
         <div>
           <h2 id="performance" className={S.ecosystemH2}>
             Performance
@@ -441,30 +449,14 @@ function EcosystemPage(props: any) {
           </div>
         </div>
 
-        <h2 id="deals" className={S.ecosystemH2} style={{ paddingBottom: '0px' }}>
-          Deal rates
-        </h2>
-        {state.successFailureRates != undefined ? (
-          <div className={S.ecosystemPerformance} style={{ marginTop: '0px' }}>
-            <div className={S.ecosystemShuttleData}>
-              <div className={S.ecosystemSection}>
-                <div className={S.ecosystemStatCard}>
-                  <div className={S.ecosystemStatValue} style={{fontSize: "30px", color: "#76ff01"}}>{state.successFailureRates['dealSuccessRate']}</div>
-                  <div className={S.ecosystemStatLabel}>Success Rate</div>
-                </div>
-              </div>
-            </div>
-            <div className={S.ecosystemShuttleData}>
-
-              <div className={S.ecosystemSection}>
-                <div className={S.ecosystemStatCard}>
-                  <div className={S.ecosystemStatValue} style={{ fontSize: "30px", color: "#cb1b3f"}}>{state.successFailureRates['dealFailureRate']}</div>
-                  <div className={S.ecosystemStatLabel} style={{ color: "#cb1b3f"}}>Failure Rate</div>
-                </div>
-              </div>
-            </div>
+        {state.successFailureRates !== undefined ? (
+          <div>
+            <h2 id="deals" className={S.ecosystemH2} style={{ paddingBottom: '16px' }}>
+              Deal rates
+            </h2>
+            <ProgressBar completed={state.successFailureRates['dealSuccessRate']} />
           </div>
-        ) : null }
+        ) : null}
 
         <h2 id="deals" className={S.ecosystemH2} style={{ paddingBottom: '0px' }}>
           Deals
@@ -486,7 +478,6 @@ function EcosystemPage(props: any) {
             />
           </div>
         ) : null}
-
         <div className={S.ecosystemPerformanceTable}>
           <div>
             {graph.data ? (


### PR DESCRIPTION
Added success and failure rate on ecosystem page.

<img width="801" alt="image" src="https://user-images.githubusercontent.com/4479171/209845905-ae2a8433-350f-4d74-be27-33f270f2d76f.png">

@APiligrim will modify the section based on our branding / design preference.
![Screenshot Capture - 2023-01-05 - 13-07-34](https://user-images.githubusercontent.com/28320272/210850094-bc141ea0-5f93-41b7-ab70-a48137ef248f.png)

