### PR TITLE
Fix error on performance page

### DIFF
--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -449,7 +449,7 @@ function EcosystemPage(props: any) {
           </div>
         </div>
 
-        {state.successFailureRates !== undefined ? (
+        {state.successFailureRates !== null ? (
           <div>
             <h2 id="deals" className={S.ecosystemH2} style={{ paddingBottom: '16px' }}>
               Deal rates


### PR DESCRIPTION
This pr fixes an operator error on the performance page. With the `null` instead of `undefined` it will display the Deal rate once the rate is loaded and is not null. 