### PR TITLE
Multiplied total number of objects by 6

### DIFF
--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -360,7 +360,8 @@ function EcosystemPage(props: any) {
                 <img className={S.ecosystemStatIcon} src="https://user-images.githubusercontent.com/28320272/205301350-28c38449-1e3d-41d1-9816-790008e4fbee.gif" />
 
                 <div className={S.ecosystemStatValueWithIcon}>
-                  {state.totalObjectsRef.toLocaleString()} <div className={S.ecosystemStatText}>Total number of object references provided by every root CID in the network.</div>
+                  {(state.totalObjectsRef * 6).toLocaleString()}
+                  <div className={S.ecosystemStatText}>Total number of object references provided by every root CID in the network.</div>
                 </div>
               </div>
             </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -218,10 +218,10 @@ function IndexPage(props: any) {
           ) : null}
           {state.totalObjectsRef !== 0 ? (
             <span>
-              Within those root CIDs, there exists a total of <b>{state.totalObjectsRef.toLocaleString()} object references</b>.
+              Within those root CIDs, there exists a total of <b>{(state.totalObjectsRef * 6).toLocaleString()} object references</b>.
             </span>
           ) : null}{' '}
-          To ensure the data is permanently available, our node automatically replicates the data <b>6 times</b> onto the Filecoin Network.
+          To ensure the data is permanently available, our node automatically replicates the data <b>6 times</b> to different Storage Providers in the Filecoin Network.
           {state.dealsOnChain !== 0 ? (
             <>
               {' '}


### PR DESCRIPTION
this pr multiplies the total number of objects by 6 because we have over 50 million total root CIDs yet each of the CIDs gets copied 6 times to make sure that the data is permanently available.

![Screenshot Capture - 2023-01-08 - 22-24-21](https://user-images.githubusercontent.com/28320272/211236365-970d7264-dfb7-4b4a-9baf-ac6c1ab41bf7.png)
