### PR TITLE
Add PUT and DELETE to cors middleware

### DIFF
--- a/common/server.ts
+++ b/common/server.ts
@@ -14,6 +14,6 @@ export function initMiddleware(middleware) {
 
 export const cors = initMiddleware(
   Cors({
-    methods: ['GET', 'POST', 'OPTIONS'],
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   })
 );


### PR DESCRIPTION
Deleting API keys is currently throwing a CORS error on prod due to DELETE missing. Also adding PUT since we have API endpoints that use it, like password changing.

![image](https://user-images.githubusercontent.com/2850013/211400539-3111c593-07c3-4579-a4f2-435bd83fce08.png)

Note: Token hash referenced in the image is expired, will delete after this goes through.
