### PR TITLE
Update Storage Provider table

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -40,7 +40,6 @@ export const regex = {
   password: /^(?=.*[A-Za-z])(?=.*\d).{8,}$/,
 };
 
-
 function getMetricsHost(): string {
   if (process.env.NEXT_PUBLIC_ESTUARY_METRICS_API) {
     return process.env.NEXT_PUBLIC_ESTUARY_METRICS_API;
@@ -68,5 +67,75 @@ function getAPIHost(): string {
 
 export const api = {
   host: getAPIHost(),
-  metricsHost: getMetricsHost()
+  metricsHost: getMetricsHost(),
+};
+
+export const staticEnvironmentPayload = {
+  uuids: [
+    {
+      Uuid: '766557e4-1c14-4bef-a5b2-d974bbb2d848',
+      Name: 'Estuary API',
+    },
+    {
+      Uuid: '60352064-7b2c-4597-baf6-9df128e9242b',
+      Name: 'Shuttle-1',
+    },
+    {
+      Uuid: 'ed16760d-ec36-4d71-b46f-378428c1d774',
+      Name: 'Shuttle-2',
+    },
+
+    {
+      Uuid: '266fbb9d-56a1-4dea-9b99-9f28054c5522',
+      Name: 'Shuttle-4',
+    },
+    {
+      Uuid: '20e7cd76-c65c-48a1-871e-39b692f051b3',
+      Name: 'Shuttle-5',
+    },
+    {
+      Uuid: '266fbb9d-56a1-4dea-9b99-9f28054c5522',
+      Name: 'Shuttle-6',
+    },
+    {
+      Uuid: '3c924716-f30e-4afd-a073-98204e4a96a7',
+      Name: 'Shuttle-7',
+    },
+    {
+      Uuid: '8ceea3cd-7608-4428-8d6b-99f2acc80ce3',
+      Name: 'Shuttle-8',
+    },
+    {
+      Uuid: '20e7cd76-c65c-48a1-871e-39b692f051b3',
+      Name: '(NSQ) Queue Server',
+    },
+    {
+      Uuid: 'a972ec78-d59a-47a4-b110-dd6c5dfc0e60',
+      Name: 'DB Load Balancer',
+    },
+    {
+      Uuid: 'ec7e5c3f-28e4-48ec-8df2-4630657bcc8e',
+      Name: 'DB Server # 1',
+    },
+    {
+      Uuid: '78e4e282-305f-4fde-9e89-3f58aed69c9c',
+      Name: 'DB Server # 2',
+    },
+    {
+      Uuid: 'fec7f5fb-a457-4d87-b334-c08584df1611',
+      Name: 'DB Server # 3',
+    },
+    {
+      Uuid: '43cfdfa5-6037-4520-9e4c-c46f4d3686a1',
+      Name: 'Autoretrieve Server',
+    },
+    {
+      Uuid: 'a8e5d22b-13ef-4dc9-adcf-a3b2bb4a8863',
+      Name: 'Upload Proxy Server',
+    },
+    {
+      Uuid: 'e4d0efb1-1b5b-4aaf-a6ed-37c4a6cc2c6f',
+      Name: 'Backup Server',
+    },
+  ],
 };

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -70,7 +70,17 @@ export const api = {
   metricsHost: getMetricsHost(),
 };
 
+// get current date and 30 days before
+var today = new Date();
+var priorDate = new Date(new Date().setDate(today.getDate() - 30));
+
+// reformat date
+var before = today.getDate() + '-' + (today.getMonth() + 1) + '-' + today.getFullYear();
+var after = priorDate.getDate() + '-' + (priorDate.getMonth() + 1) + '-' + priorDate.getFullYear();
+
 export const staticEnvironmentPayload = {
+  createdBefore: before,
+  createdAfter: after,
   uuids: [
     {
       Uuid: '766557e4-1c14-4bef-a5b2-d974bbb2d848',

--- a/components/Footer.module.scss
+++ b/components/Footer.module.scss
@@ -18,7 +18,7 @@
 }
 
 .footerHeading {
-  color: var(--color-green);
+  color: var(--text-white);
   font-family: 'Parabole';
   -webkit-font-smoothing: antialiased;
   font-size: 24px;
@@ -57,7 +57,9 @@
 }
 
 .footerBranding {
-  background: var(--color-green);
+  background: var(--linear-gradient-green);
+  animation: gradient-animation 10s ease infinite;
+  background-size: 240% 240%;
   border-top: 0.5px dashed var(--text-space-gray);
   display: flex;
   flex-direction: column;
@@ -141,5 +143,17 @@
   @media (max-width: 768px) {
     font-size: 12px;
     padding-left: 5vw;
+  }
+}
+
+@keyframes gradient-animation {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
   }
 }

--- a/components/Hero.module.scss
+++ b/components/Hero.module.scss
@@ -9,7 +9,7 @@
 }
 
 .gradient {
-  background: linear-gradient(321deg, #71e760, #d9e868, #7de9a0, #b6ec7d);
+  background: var(--linear-gradient-green);
   animation: gradient-animation 10s ease infinite;
   background-size: 240% 240%;
 }

--- a/components/ProgressBar.module.scss
+++ b/components/ProgressBar.module.scss
@@ -6,7 +6,9 @@
 
 .fillerStyles {
   height: 100%;
-  background-color: var(--color-green);
+  background: var(--linear-gradient-green);
+  animation: gradient-animation 10s ease infinite;
+  background-size: 240% 240%;
   border-radius: inherit;
   text-align: right;
   transition: width 1s ease-in-out;
@@ -34,5 +36,17 @@
 
   @media (max-width: 768px) {
     font-size: 16px;
+  }
+}
+
+@keyframes gradient-animation {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
   }
 }

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -1,15 +1,17 @@
 import styles from '@components/ProgressBar.module.scss';
+import LoaderSpinner from './LoaderSpinner';
 
 export default function ProgressBar(props) {
-  const { bgcolor, completed } = props;
+  const { completed } = props;
   const completedRounded = Math.round(completed * 100) / 100;
 
   const notCompleted = Math.round((100 - completed) * 100) / 100;
+  console.log(completedRounded, 'completed rounded');
   return (
     <div style={{ display: 'grid', rowGap: '12px' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-        <p className={styles.labelTitle}>Success: {`${completedRounded}%`} </p>
-        <p className={styles.labelTitle}>Failure: {`${notCompleted}%`} </p>
+        <p className={styles.labelTitle}>Success: {isNaN(completedRounded) ? <LoaderSpinner /> : `${completedRounded}%`} </p>
+        <p className={styles.labelTitle}>Failure: {isNaN(notCompleted) ? <LoaderSpinner /> : `${notCompleted}%`} </p>
       </div>
 
       <div className={styles.containerStyles}>

--- a/components/icons/DealsIcon.tsx
+++ b/components/icons/DealsIcon.tsx
@@ -1,10 +1,10 @@
 export default function DealsIcon(props: any) {
   return (
-    <svg {...props} width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-reactroot="">
-      <rect stroke-linejoin="round" stroke-linecap="round" stroke-width="0.5" stroke="#221b38" transform="matrix(1 0 0 -1 8 5)" height="3" width="8"></rect>
-      <rect stroke-linejoin="round" stroke-linecap="round" stroke-width="0.5" stroke="#221b38" fill="none" height="11" width="20" y="11" x="2"></rect>
-      <rect stroke-linejoin="round" stroke-linecap="round" stroke-width="0.5" stroke="#221b38" fill="none" transform="matrix(1 0 0 -1 2 11)" height="6" width="20"></rect>
-      <path stroke-linejoin="round" stroke-linecap="round" stroke-width="0.5" stroke="#221b38" fill="none" d="M8 15H16L17 11H7L8 15Z"></path>
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+      <path stroke="currentColor" strokeWidth="0.5" d="M0 0H8V3H0z" transform="matrix(1 0 0 -1 8 5)"></path>
+      <path stroke="currentColor" strokeWidth="0.5" d="M2 11H22V22H2z"></path>
+      <path stroke="currentColor" strokeWidth="0.5" d="M0 0H20V6H0z" transform="matrix(1 0 0 -1 2 11)"></path>
+      <path stroke="currentColor" strokeWidth="0.5" d="M8 15h8l1-4H7l1 4z"></path>
     </svg>
   );
 }

--- a/components/icons/DealsIcon.tsx
+++ b/components/icons/DealsIcon.tsx
@@ -1,0 +1,10 @@
+export default function DealsIcon(props: any) {
+  return (
+    <svg {...props} width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-reactroot="">
+      <rect stroke-linejoin="round" stroke-linecap="round" stroke-width="0.5" stroke="#221b38" transform="matrix(1 0 0 -1 8 5)" height="3" width="8"></rect>
+      <rect stroke-linejoin="round" stroke-linecap="round" stroke-width="0.5" stroke="#221b38" fill="none" height="11" width="20" y="11" x="2"></rect>
+      <rect stroke-linejoin="round" stroke-linecap="round" stroke-width="0.5" stroke="#221b38" fill="none" transform="matrix(1 0 0 -1 2 11)" height="6" width="20"></rect>
+      <path stroke-linejoin="round" stroke-linecap="round" stroke-width="0.5" stroke="#221b38" fill="none" d="M8 15H16L17 11H7L8 15Z"></path>
+    </svg>
+  );
+}

--- a/components/icons/ErrorIcon.tsx
+++ b/components/icons/ErrorIcon.tsx
@@ -1,17 +1,13 @@
 export default function ErrorIcon(props: any) {
   return (
-    <svg {...props} width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-reactroot="">
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="none" viewBox="0 0 24 24">
       <path
-        stroke-linejoin="round"
-        stroke-linecap="round"
-        stroke-miterlimit="10"
-        stroke-width="1"
-        stroke="#221b38"
-        fill="none"
-        d="M19.76 5.23C15.84 5.23 12 2 12 2C12 2 8.16002 5.23 4.24002 5.23C4.24002 5.23 1.87002 16.99 12 22C22.13 16.99 19.76 5.23 19.76 5.23Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeMiterlimit="10"
+        d="M19.76 5.23C15.84 5.23 12 2 12 2S8.16 5.23 4.24 5.23c0 0-2.37 11.76 7.76 16.77 10.13-5.01 7.76-16.77 7.76-16.77zM12 8v5M11.99 16H12"
       ></path>
-      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M12 8V13"></path>
-      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M11.9901 16H12.0001"></path>
     </svg>
   );
 }

--- a/components/icons/ErrorIcon.tsx
+++ b/components/icons/ErrorIcon.tsx
@@ -1,0 +1,17 @@
+export default function ErrorIcon(props: any) {
+  return (
+    <svg {...props} width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-reactroot="">
+      <path
+        stroke-linejoin="round"
+        stroke-linecap="round"
+        stroke-miterlimit="10"
+        stroke-width="1"
+        stroke="#221b38"
+        fill="none"
+        d="M19.76 5.23C15.84 5.23 12 2 12 2C12 2 8.16002 5.23 4.24002 5.23C4.24002 5.23 1.87002 16.99 12 22C22.13 16.99 19.76 5.23 19.76 5.23Z"
+      ></path>
+      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M12 8V13"></path>
+      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M11.9901 16H12.0001"></path>
+    </svg>
+  );
+}

--- a/components/icons/SignalIcon.tsx
+++ b/components/icons/SignalIcon.tsx
@@ -1,11 +1,7 @@
 export default function SignalIcon(props: any) {
   return (
-    <svg {...props} width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-reactroot="">
-      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M20 2V22"></path>
-      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M16 6V22"></path>
-      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M12 10V22"></path>
-      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M8 14V22"></path>
-      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M4 18V22"></path>
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="none" viewBox="0 0 24 24">
+      <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeMiterlimit="10" d="M20 2v20M16 6v16M12 10v12M8 14v8M4 18v4"></path>
     </svg>
   );
 }

--- a/components/icons/SignalIcon.tsx
+++ b/components/icons/SignalIcon.tsx
@@ -1,0 +1,11 @@
+export default function SignalIcon(props: any) {
+  return (
+    <svg {...props} width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-reactroot="">
+      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M20 2V22"></path>
+      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M16 6V22"></path>
+      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M12 10V22"></path>
+      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M8 14V22"></path>
+      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M4 18V22"></path>
+    </svg>
+  );
+}

--- a/components/icons/UserCheckedIcon.tsx
+++ b/components/icons/UserCheckedIcon.tsx
@@ -1,10 +1,10 @@
 export default function UserCheckedIcon(props: any) {
   return (
-    <svg {...props} width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-reactroot="">
-      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M16 10.6L18.25 13L22 9"></path>
-      <circle stroke-linejoin="round" stroke-width="1" stroke="#221b38" fill="none" r="4" cy="7" cx="10"></circle>
-      <path fill="none" d="M13 15H7C4.23858 15 2 17.2386 2 20V21H18V20C18 17.2386 15.7614 15 13 15Z"></path>
-      <path stroke-linejoin="round" stroke-linecap="round" stroke-width="1" stroke="#221b38" d="M18 21V20C18 17.2386 15.7614 15 13 15H7C4.23858 15 2 17.2386 2 20V21"></path>
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="none" viewBox="0 0 24 24">
+      <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeMiterlimit="10" d="M16 10.6l2.25 2.4L22 9"></path>
+      <circle cx="10" cy="7" r="4" stroke="currentColor" strokeLinejoin="round"></circle>
+      <path d="M13 15H7a5 5 0 00-5 5v1h16v-1a5 5 0 00-5-5z"></path>
+      <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" d="M18 21v-1a5 5 0 00-5-5H7a5 5 0 00-5 5v1"></path>
     </svg>
   );
 }

--- a/components/icons/UserCheckedIcon.tsx
+++ b/components/icons/UserCheckedIcon.tsx
@@ -1,0 +1,10 @@
+export default function UserCheckedIcon(props: any) {
+  return (
+    <svg {...props} width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-reactroot="">
+      <path stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-width="1" stroke="#221b38" d="M16 10.6L18.25 13L22 9"></path>
+      <circle stroke-linejoin="round" stroke-width="1" stroke="#221b38" fill="none" r="4" cy="7" cx="10"></circle>
+      <path fill="none" d="M13 15H7C4.23858 15 2 17.2386 2 20V21H18V20C18 17.2386 15.7614 15 13 15Z"></path>
+      <path stroke-linejoin="round" stroke-linecap="round" stroke-width="1" stroke="#221b38" d="M18 21V20C18 17.2386 15.7614 15 13 15H7C4.23858 15 2 17.2386 2 20V21"></path>
+    </svg>
+  );
+}

--- a/global.scss
+++ b/global.scss
@@ -125,6 +125,7 @@ body {
 
   --color-green: #76ff01;
   --color-green-shadow: #4fa406;
+  --linear-gradient-green: linear-gradient(321deg, #76ff01, #d9e868, #90e446, #b6ec7d);
   --main-background: rgba(246, 246, 246, 1);
   --main-background-white: #ffffff;
   --main-background-foreground: rgba(240, 240, 240, 1);

--- a/pages/StorageProvidersTable.module.scss
+++ b/pages/StorageProvidersTable.module.scss
@@ -57,7 +57,9 @@
   color: var(--text-white);
   text-decoration: none;
 
-  :hover {
+ &:hover{
+    cursor: pointer;
+    transition: 200ms ease all;
     color: var(--color-green);
   }
 }

--- a/pages/StorageProvidersTable.module.scss
+++ b/pages/StorageProvidersTable.module.scss
@@ -1,5 +1,5 @@
 .table {
-  color:var(--text-white);
+  color: var(--text-white);
   border: 1px dashed var(--text-space-gray);
   width: 100%;
   border-collapse: collapse;
@@ -22,14 +22,14 @@
   font-family: 'Mono';
   overflow: hidden;
   text-overflow: ellipsis;
-  border-bottom: 0.5px solid var(--text-space-gray);
+  border-bottom: 1px dashed var(--text-space-gray);
   border-collapse: collapse;
   background: var(--text-white);
   color: 'black';
 }
 
 .td {
-  border-bottom: 0.5px solid var(--text-space-gray);
+  border-bottom: 1px dashed var(--text-space-gray);
   border-left: none;
   border-right: none;
   transition: 0.5s;
@@ -51,4 +51,22 @@
 
 .thLabel {
   margin-right: 4px;
+}
+
+.link {
+  color: var(--text-white);
+  text-decoration: none;
+
+  :hover {
+    color: var(--color-green);
+  }
+}
+
+.loaderContainer {
+  text-align: center;
+  margin-top: 80px;
+}
+
+.displayNone {
+  display: none;
 }

--- a/pages/StorageProvidersTable.module.scss
+++ b/pages/StorageProvidersTable.module.scss
@@ -1,0 +1,54 @@
+.table {
+  color:var(--text-white);
+  border: 1px dashed var(--text-space-gray);
+  width: 100%;
+  border-collapse: collapse;
+  th,
+  td {
+    width: 1%;
+  }
+}
+
+.th {
+  position: sticky;
+  top: 70px;
+  box-shadow: 0 2px 2px -1px var(--text-black);
+  padding: 17px 20px;
+  text-align: left;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  font-weight: 500;
+  font-size: 11px;
+  font-family: 'Mono';
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-bottom: 0.5px solid var(--text-space-gray);
+  border-collapse: collapse;
+  background: var(--text-white);
+  color: 'black';
+}
+
+.td {
+  border-bottom: 0.5px solid var(--text-space-gray);
+  border-left: none;
+  border-right: none;
+  transition: 0.5s;
+  padding: 17px 20px;
+  border-collapse: collapse;
+  font-family: 'Mono';
+  font-size: 16px;
+}
+
+.svgIcon {
+  position: absolute;
+  top: 48%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  margin: auto;
+  text-align: center;
+}
+
+.thLabel {
+  margin-right: 4px;
+}

--- a/pages/StorageProvidersTable.tsx
+++ b/pages/StorageProvidersTable.tsx
@@ -1,0 +1,96 @@
+import style from '@pages/StorageProvidersTable.module.scss';
+
+import * as R from '@common/requests';
+import * as U from '@common/utilities';
+import * as React from 'react';
+
+import DealsIcon from '@root/components/icons/DealsIcon';
+import ErrorIcon from '@root/components/icons/ErrorIcon';
+import UserCheckedIcon from '@root/components/icons/UserCheckedIcon';
+import SignalIcon from '@root/components/icons/SignalIcon';
+
+export interface MinerDataProps {
+  miner: string;
+  dealCount: number;
+  errorCount: number;
+}
+
+export async function getServerSideProps(context) {
+  const viewer = await U.getViewerFromHeader(context.req.headers);
+
+  return {
+    props: { viewer, ...context.params, api: process.env.NEXT_PUBLIC_ESTUARY_API, hostname: `https://${context.req.headers.host}` },
+  };
+}
+
+function StorageProvidersTable(props: any) {
+  const [state, setState] = React.useState([]);
+
+  let minerNames = [];
+  let eachMiner = [];
+  let minerData: MinerDataProps[] = [];
+
+  React.useEffect(() => {
+    const run = async () => {
+      const miners = await R.get('/public/miners/', process.env.NEXT_PUBLIC_ESTUARY_API);
+
+      for (let miner of miners) {
+        minerNames.push(miner.addr);
+      }
+
+      minerNames.map((miner) => {
+        eachMiner.push(miner);
+      });
+
+      eachMiner.map(async (miner) => {
+        const response = await R.get(`/public/miners/stats/${miner}`, process.env.NEXT_PUBLIC_ESTUARY_API);
+
+        minerData.push(response);
+        if (minerData.length == minerNames.length) {
+          return setState(minerData);
+        }
+      });
+    };
+
+    run();
+  }, []);
+
+  return (
+    <table className={style.table}>
+      <div>{minerData}</div>
+      <tr>
+        <th className={style.th} style={{ color: 'black', fontSize: '12px' }}>
+          Index
+          <SignalIcon className={style.svgIcon} style={{ height: '20px' }} />
+        </th>
+        <th className={style.th} style={{ color: 'black', fontSize: '12px' }}>
+          <span className={style.thLabel}>Storage Provider's ID</span> <UserCheckedIcon className={style.svgIcon} style={{ height: '20px' }} />
+        </th>
+        <th className={style.th} style={{ color: 'black', fontSize: '12px' }}>
+          <span className={style.thLabel}> Deals</span>
+          <DealsIcon className={style.svgIcon} style={{ height: '20px' }} />
+        </th>
+        <th className={style.th} style={{ color: 'black', fontSize: '12px' }}>
+          <span className={style.thLabel}> Error Count</span>
+          <ErrorIcon className={style.svgIcon} style={{ height: '20px' }} />
+        </th>
+      </tr>
+
+      {state.length !== null
+        ? state.map((item, index) => {
+            const { miner, dealCount, errorCount } = item;
+            return (
+              <tr className={style.tr}>
+                <td className={style.td}>{index}</td>
+                <td className={style.td}>{miner}</td>
+                <td className={style.td}>{dealCount}</td>
+                <td className={style.td}>{errorCount}</td>
+              </tr>
+            );
+          })
+        : null}
+    </table>
+  );
+}
+
+export default StorageProvidersTable;

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -56,16 +56,6 @@ function EcosystemPage(props: any) {
   });
   const [graph, setGraph] = React.useState({ data: null, dealsSealedBytes: 0 });
 
-  // get current date and 30 days before
-  var today = new Date();
-  var priorDate = new Date(new Date().setDate(today.getDate() - 30));
-
-  // reformat date
-  var before = today.getDate() + '-' + (today.getMonth() + 1) + '-' + today.getFullYear();
-  var after = priorDate.getDate() + '-' + (priorDate.getMonth() + 1) + '-' + priorDate.getFullYear();
-
-  //  static payload
-
   React.useEffect(() => {
     const run = async () => {
       const successFailRateStats = await R.get('/api/v1/stats/storage-rates', C.api.metricsHost);
@@ -429,8 +419,13 @@ function EcosystemPage(props: any) {
             ) : null}
           </div>
 
-          <span className={S.flink}>All of the storage providers that take storage from this Estuary node.</span>
-
+          <p className={S.flink} style={{ marginBottom: '8px' }}>
+            This table displays all of the&nbsp;
+            <a href="https://docs.estuary.tech/get-provider-added" className={S.link}>
+              Storage Providers
+            </a>
+            &nbsp;that take storage from this Estuary node.{' '}
+          </p>
           <StorageProvidersTable />
         </div>
       </div>

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -10,9 +10,10 @@ import Chart from '@components/Chart';
 import Page from '@components/Page';
 
 import Footer from '@root/components/Footer';
-import ResponsiveNavbar from '@root/components/ResponsiveNavbar';
-import ProgressBar from '@root/components/ProgressBar';
 import Hero from '@root/components/Hero';
+import ProgressBar from '@root/components/ProgressBar';
+import ResponsiveNavbar from '@root/components/ResponsiveNavbar';
+import StorageProvidersTable from './StorageProvidersTable';
 
 export async function getServerSideProps(context) {
   const viewer = await U.getViewerFromHeader(context.req.headers);
@@ -64,84 +65,13 @@ function EcosystemPage(props: any) {
   var after = priorDate.getDate() + '-' + (priorDate.getMonth() + 1) + '-' + priorDate.getFullYear();
 
   //  static payload
-  var staticEnvironmentPayload = {
-    createdBefore: before,
-    createdAfter: after,
-    uuids: [
-      {
-        Uuid: '766557e4-1c14-4bef-a5b2-d974bbb2d848',
-        Name: 'Estuary API',
-      },
-      {
-        Uuid: '60352064-7b2c-4597-baf6-9df128e9242b',
-        Name: 'Shuttle-1',
-      },
-      {
-        Uuid: 'ed16760d-ec36-4d71-b46f-378428c1d774',
-        Name: 'Shuttle-2',
-      },
-
-      {
-        Uuid: '266fbb9d-56a1-4dea-9b99-9f28054c5522',
-        Name: 'Shuttle-4',
-      },
-      {
-        Uuid: '20e7cd76-c65c-48a1-871e-39b692f051b3',
-        Name: 'Shuttle-5',
-      },
-      {
-        Uuid: '266fbb9d-56a1-4dea-9b99-9f28054c5522',
-        Name: 'Shuttle-6',
-      },
-      {
-        Uuid: '3c924716-f30e-4afd-a073-98204e4a96a7',
-        Name: 'Shuttle-7',
-      },
-      {
-        Uuid: '8ceea3cd-7608-4428-8d6b-99f2acc80ce3',
-        Name: 'Shuttle-8',
-      },
-      {
-        Uuid: '20e7cd76-c65c-48a1-871e-39b692f051b3',
-        Name: '(NSQ) Queue Server',
-      },
-      {
-        Uuid: 'a972ec78-d59a-47a4-b110-dd6c5dfc0e60',
-        Name: 'DB Load Balancer',
-      },
-      {
-        Uuid: 'ec7e5c3f-28e4-48ec-8df2-4630657bcc8e',
-        Name: 'DB Server # 1',
-      },
-      {
-        Uuid: '78e4e282-305f-4fde-9e89-3f58aed69c9c',
-        Name: 'DB Server # 2',
-      },
-      {
-        Uuid: 'fec7f5fb-a457-4d87-b334-c08584df1611',
-        Name: 'DB Server # 3',
-      },
-      {
-        Uuid: '43cfdfa5-6037-4520-9e4c-c46f4d3686a1',
-        Name: 'Autoretrieve Server',
-      },
-      {
-        Uuid: 'a8e5d22b-13ef-4dc9-adcf-a3b2bb4a8863',
-        Name: 'Upload Proxy Server',
-      },
-      {
-        Uuid: 'e4d0efb1-1b5b-4aaf-a6ed-37c4a6cc2c6f',
-        Name: 'Backup Server',
-      },
-    ],
-  };
 
   React.useEffect(() => {
     const run = async () => {
       const successFailRateStats = await R.get('/api/v1/stats/storage-rates', C.api.metricsHost);
       const miners = await R.get('/public/miners', props.api);
       const stats = await R.get('/api/v1/stats/info', C.api.metricsHost);
-      const environment = await R.post('/api/v1/environment/equinix/list/usages', staticEnvironmentPayload, C.api.metricsHost);
+      const environment = await R.post('/api/v1/environment/equinix/list/usages', C.staticEnvironmentPayload, C.api.metricsHost);
 
       if ((miners && miners.error) || (stats && stats.error)) {
         return setState({
@@ -499,49 +429,9 @@ function EcosystemPage(props: any) {
             ) : null}
           </div>
 
-          <div className={S.fa}>
-            <div className={S.fcol4}>
-              <span className={S.flink} style={{ fontSize: '16px' }}>
-                Index
-              </span>
-            </div>
-            <div className={S.fcolfull}>
-              <span className={S.flink}>All of the storage providers that take storage from this Estuary node.</span>
-            </div>
-          </div>
+          <span className={S.flink}>All of the storage providers that take storage from this Estuary node.</span>
 
-          {state.miners.map((each, index) => {
-            if (each.suspended) {
-              return null;
-            }
-
-            const indexValue = U.pad(index, 4);
-
-            return (
-              <div className={S.fam} key={each.addr}>
-                <div className={S.fcol4}>
-                  <a className={S.flink} href={`/providers/stats/${each.addr}`}>
-                    {indexValue} {!U.isEmpty(each.name) ? `— ${each.name}` : null}
-                  </a>
-                </div>
-                <div className={S.fcol4}>
-                  <a className={S.flink} href={`/providers/stats/${each.addr}`}>
-                    ➝ {each.addr}/stats
-                  </a>
-                </div>
-                <div className={S.fcol4}>
-                  <a className={S.flink} href={`/providers/deals/${each.addr}`}>
-                    ➝ {each.addr}/deals
-                  </a>
-                </div>
-                <div className={S.fcol4}>
-                  <a className={S.flink} href={`/providers/errors/${each.addr}`}>
-                    ➝ {each.addr}/errors
-                  </a>
-                </div>
-              </div>
-            );
-          })}
+          <StorageProvidersTable />
         </div>
       </div>
       <Footer />

--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -413,7 +413,7 @@ function EcosystemPage(props: any) {
           </div>
         ) : null}
         <div className={S.ecosystemPerformanceTable}>
-          <div>
+          <div style={{ marginBottom: 'var(--main-page-row-gap)' }}>
             {graph.data ? (
               <div className={S.fa}>
                 {graph.data.map((each) => {

--- a/pages/index.module.scss
+++ b/pages/index.module.scss
@@ -279,7 +279,6 @@ a.flink {
   font-family: 'Mono';
   font-size: 16px;
   height: 56px;
-  padding: 0 15px 0 15px;
   text-decoration: none;
   transition: 200ms ease all;
 
@@ -448,7 +447,6 @@ a.flink {
 .ecosystemPerformance {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 20px;
 }
 
 .ecosystemSectionWithIcon {
@@ -596,4 +594,15 @@ a.flink {
   font-size: 12px;
   margin-top: 8px;
   text-transform: uppercase;
+}
+
+.link{
+  color: var(--text-white);
+  text-decoration: none;
+
+  &:hover{
+    cursor: pointer;
+    transition: 200ms ease all;
+    color: var(--color-green);
+  }
 }

--- a/pages/providers/stats/[id].tsx
+++ b/pages/providers/stats/[id].tsx
@@ -41,6 +41,7 @@ function MinerStatsPage(props: any) {
   React.useEffect(() => {
     const run = async () => {
       const response = await R.get(`/public/miners/stats/${props.id}`, props.api);
+
       let iex;
       try {
         const iexResponse = await fetch('https://cloud.iexapis.com/stable/crypto/filusdt/price?token=pk_aa330a89a4724944ae1a525879a19f2d');
@@ -62,8 +63,6 @@ function MinerStatsPage(props: any) {
 
     run();
   }, []);
-
-  console.log('state', state);
 
   const sidebarElement = props.viewer ? <AuthenticatedSidebar viewer={props.viewer} /> : null;
 


### PR DESCRIPTION
This pr updates the SP table so that people can see the number of sorted deals each provider makes without having to click on them separately. 

Is it useful to display the `Error Count` or should we display the amount of storage each SP stores? I couldn't find that information 👀 
![2023-01-09 20 10 23](https://user-images.githubusercontent.com/28320272/211439696-e71c3e32-fbb9-4535-8162-d9c60754e171.gif)

Also added the same gradient to the footer and progress bar as the header 
![Screenshot Capture - 2023-01-09 - 15-55-29](https://user-images.githubusercontent.com/28320272/211406543-ab1ce013-d326-48cc-8589-83b917e5e3ad.png)
