### PR TITLE
Prevent mixing up session and service tokens, fix admin login, remove authenticate via API key

### DIFF
--- a/pages/api-admin.tsx
+++ b/pages/api-admin.tsx
@@ -172,50 +172,52 @@ function APIPage(props: any) {
                 </th>
               </tr>
               {state.keys && state.keys.length
-                ? state.keys.map((k, index) => {
-                    const expiryDate = new Date(k.expiry);
-                    const currentDate = new Date();
-                    const isExpired = expiryDate < currentDate;
+                ? state.keys
+                    .filter((k) => !k.isSession)
+                    .map((k, index) => {
+                      const expiryDate = new Date(k.expiry);
+                      const currentDate = new Date();
+                      const isExpired = expiryDate < currentDate;
 
-                    return (
-                      <tr key={k.tokenHash ? k.tokenHash : k.token} className={tstyles.tr}>
-                        <td style={{ opacity: isExpired ? 0.2 : 1 }} className={tstyles.td}>
-                          {k.label}
-                        </td>
-                        <td style={{ opacity: isExpired ? 0.2 : 1 }} className={tstyles.td}>
-                          {k.token ? k.token : REDACTED_TOKEN_STRING} {viewerToken === k.token ? <strong>(current browser session)</strong> : null}
-                        </td>
-                        <td style={{ opacity: isExpired ? 0.2 : 1 }} className={tstyles.td}>
-                          {U.toDate(k.expiry)}
-                        </td>
-                        <td className={tstyles.td}>
-                          <button
-                            onClick={async () => {
-                              const confirm = window.confirm('Are you sure you want to delete this key?');
-                              if (!confirm) {
-                                return;
-                              }
+                      return (
+                        <tr key={k.tokenHash ? k.tokenHash : k.token} className={tstyles.tr}>
+                          <td style={{ opacity: isExpired ? 0.2 : 1 }} className={tstyles.td}>
+                            {k.label}
+                          </td>
+                          <td style={{ opacity: isExpired ? 0.2 : 1 }} className={tstyles.td}>
+                            {k.token ? k.token : REDACTED_TOKEN_STRING} {viewerToken === k.token ? <strong>(current browser session)</strong> : null}
+                          </td>
+                          <td style={{ opacity: isExpired ? 0.2 : 1 }} className={tstyles.td}>
+                            {U.toDate(k.expiry)}
+                          </td>
+                          <td className={tstyles.td}>
+                            <button
+                              onClick={async () => {
+                                const confirm = window.confirm('Are you sure you want to delete this key?');
+                                if (!confirm) {
+                                  return;
+                                }
 
-                              const response = await R.del(`/user/api-keys/${k.tokenHash ? k.tokenHash : k.token}`, props.api);
-                              if (viewerToken === k.token) {
-                                window.location.href = '/';
-                                return;
-                              }
+                                const response = await R.del(`/user/api-keys/${k.tokenHash ? k.tokenHash : k.token}`, props.api);
+                                if (viewerToken === k.token) {
+                                  window.location.href = '/';
+                                  return;
+                                }
 
-                              const keys = await R.get('/user/api-keys', props.api);
-                              if (keys && !keys.error) {
-                                setState({ ...state, keys });
-                              }
-                            }}
-                            className={tstyles.tdbutton}
-                          >
-                            {isExpired ? 'Delete expired' : `Revoke`}
-                          </button>
-                          {!isExpired && k.token ? <CopyButton content={k.token} /> : null}
-                        </td>
-                      </tr>
-                    );
-                  })
+                                const keys = await R.get('/user/api-keys', props.api);
+                                if (keys && !keys.error) {
+                                  setState({ ...state, keys });
+                                }
+                              }}
+                              className={tstyles.tdbutton}
+                            >
+                              {isExpired ? 'Delete expired' : `Revoke`}
+                            </button>
+                            {!isExpired && k.token ? <CopyButton content={k.token} /> : null}
+                          </td>
+                        </tr>
+                      );
+                    })
                 : null}
             </tbody>
           </table>

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -79,12 +79,7 @@ async function handleSignIn(state: any, host) {
 }
 
 function SignInPage(props: any) {
-  const [state, setState] = React.useState({ loading: false, authLoading: false, fissionLoading: false, username: '', password: '', key: '', adminLogin: 'false' });
-
-  const authorise = null;
-  const authScenario = null;
-  const signIn = null;
-
+  const [state, setState] = React.useState({ loading: false, authLoading: false, fissionLoading: false, username: '', password: '', adminLogin: 'false' });
   return (
     <Page title="Estuary: Sign in" description="Sign in to your Estuary account." url={`${props.hostname}/sign-in`}>
       <Navigation active="SIGN_IN" />

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -114,7 +114,7 @@ function SignInPage(props: any) {
           }}
         />
 
-        <div className={styles.actions} style={{ marginTop: 10 }}>
+        <div className={styles.actions} style={{ marginTop: '16px' }}>
           <input
             type="checkbox"
             onClick={() => {
@@ -125,7 +125,7 @@ function SignInPage(props: any) {
               }
             }}
           />
-          <p style={{ fontSize: 12, marginTop: 1 }}>This user was created using estuary CLI</p>
+          <H4>This user was created using estuary CLI</H4>
         </div>
 
         <div className={styles.actions}>

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -2,7 +2,6 @@ import styles from '@pages/app.module.scss';
 
 import * as C from '@common/constants';
 import * as Crypto from '@common/crypto';
-import * as R from '@common/requests';
 import * as U from '@common/utilities';
 import * as React from 'react';
 
@@ -77,48 +76,6 @@ async function handleSignIn(state: any, host) {
       'Content-Type': 'application/json',
     },
   });
-
-  if (r.status !== 200) {
-    // NOTE(jim): We don't know the users password ever so we can't do anything on their
-    // behalf, but if they were authenticated using the old method, we can do one more retry.
-    const retryHash = await Crypto.attemptHash(state.password);
-
-    let retry = await fetch(`${host}/login`, {
-      method: 'POST',
-      body: JSON.stringify({ passwordHash: retryHash, username: state.username }),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (retry.status !== 200) {
-      return { error: 'Failed to authenticate' };
-    }
-
-    const retryJSON = await retry.json();
-    if (retryJSON.error) {
-      return retryJSON;
-    }
-
-    if (!retryJSON.token) {
-      return { error: 'Failed to authenticate' };
-    }
-
-    console.log('Authenticated using legacy scheme.');
-
-    Cookies.set(C.auth, retryJSON.token);
-
-    console.log('Attempting legacy scheme revision on your behalf');
-
-    try {
-      const response = await R.put('/user/password', { newPasswordHash: state.passwordHash }, host);
-    } catch (e) {
-      console.log('Failure:', e);
-    }
-
-    window.location.href = '/home';
-    return;
-  }
 
   const j = await r.json();
   if (j.error) {

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -12,7 +12,7 @@ import Page from '@components/Page';
 import SingleColumnLayout from '@components/SingleColumnLayout';
 import Cookies from 'js-cookie';
 
-import { H2, H3, H4, P } from '@components/Typography';
+import { H2, H4, P } from '@components/Typography';
 
 const ENABLE_SIGN_IN_WITH_FISSION = false;
 
@@ -35,24 +35,6 @@ export async function getServerSideProps(context) {
   };
 }
 
-async function handleTokenAuthenticate(state: any, host) {
-  let response = await fetch(`${host}/user/stats`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${state.key}`,
-    },
-  });
-  if (response && response.status === 403) {
-    alert('Invalid API key');
-  } else if (response && response.status === 401) {
-    alert('Expired API key');
-  } else {
-    Cookies.set(C.auth, state.key);
-    window.location.reload();
-  }
-  return response;
-}
 async function handleSignIn(state: any, host) {
   if (U.isEmpty(state.username)) {
     return { error: 'Please provide a username.' };
@@ -158,40 +140,6 @@ function SignInPage(props: any) {
             href="/sign-up"
           >
             Create an account instead
-          </Button>
-        </div>
-
-        <H3 style={{ marginTop: 32 }}>Authenticate Using Key</H3>
-        <P style={{ marginTop: 8 }}>You can authenticate using an API key if you have one.</P>
-
-        <H4 style={{ marginTop: 32 }}>API key</H4>
-        <Input
-          style={{ marginTop: 8 }}
-          placeholder="ex: ESTxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxARY"
-          name="key"
-          value={state.key}
-          onChange={(e) => setState({ ...state, [e.target.name]: e.target.value.trim() })}
-        />
-
-        <div className={styles.actions}>
-          <Button
-            style={{ width: '100%' }}
-            loading={state.authLoading ? state.authLoading : undefined}
-            onClick={async () => {
-              setState({ ...state, authLoading: true });
-              if (U.isEmpty(state.key)) {
-                alert('Please enter an API key');
-                setState({ ...state, authLoading: false });
-                return;
-              }
-              await handleTokenAuthenticate(state, props.api).then((response) => {
-                if (response.status == 403) {
-                  setState({ ...state, authLoading: false });
-                }
-              });
-            }}
-          >
-            Authenticate
           </Button>
         </div>
       </SingleColumnLayout>

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -48,8 +48,12 @@ async function handleSignIn(state: any, host) {
     return { error: 'Your username must be 1-48 characters or digits.' };
   }
 
-  // NOTE(jim) We've added a new scheme to keep things safe for users.
-  state.passwordHash = await Crypto.attemptHashWithSalt(state.password);
+  if (state.adminLogin == 'true') {
+    state.passwordHash = state.password;
+  } else {
+    // NOTE(jim) We've added a new scheme to keep things safe for users.
+    state.passwordHash = await Crypto.attemptHashWithSalt(state.password);
+  }
 
   let r = await fetch(`${host}/login`, {
     method: 'POST',
@@ -75,7 +79,7 @@ async function handleSignIn(state: any, host) {
 }
 
 function SignInPage(props: any) {
-  const [state, setState] = React.useState({ loading: false, authLoading: false, fissionLoading: false, username: '', password: '', key: '' });
+  const [state, setState] = React.useState({ loading: false, authLoading: false, fissionLoading: false, username: '', password: '', key: '', adminLogin: 'false' });
 
   const authorise = null;
   const authScenario = null;
@@ -114,6 +118,20 @@ function SignInPage(props: any) {
             }
           }}
         />
+
+        <div className={styles.actions} style={{ marginTop: 10 }}>
+          <input
+            type="checkbox"
+            onClick={() => {
+              if (state.adminLogin === 'false') {
+                setState({ ...state, adminLogin: 'true' });
+              } else {
+                setState({ ...state, adminLogin: 'false' });
+              }
+            }}
+          />
+          <p style={{ fontSize: 12, marginTop: 1 }}>This user was created using estuary CLI</p>
+        </div>
 
         <div className={styles.actions}>
           <Button


### PR DESCRIPTION
Blocked on https://github.com/application-research/estuary/pull/861

Along with https://github.com/application-research/estuary/pull/861, fixes https://github.com/application-research/estuary-www/issues/99 and https://github.com/application-research/estuary/issues/815

1. Do not render session tokens in api admin page (they should only be managed via sign in and sign out)
2. Admin login fix taken from https://github.com/application-research/estuary/issues/815#issuecomment-1364707188
3. Remove authenticate via API key since it's unnecessary now that admin login is fixed, and to prevent mixing up session and service tokens

**Warning:** if any estuary node operators have an admin user with a password that doesn't meet the 8 alphanumeric characters bcrypt requirement, they will end up getting locked out of that user when that token expires. They can create a new estuary admin by re-running setup but there may still be files tied to the original admin user. Alternatively, they can hit the change password endpoint while they have a valid token for that user and change it to a valid password.

---
New login screen (checkbox is unchecked by default):
![image](https://user-images.githubusercontent.com/2850013/211669152-b535e0eb-b119-435b-b50d-181a87af7568.png)
Note: I'm also open to not having a checkbox and just attempting the admin login on any auth failure.

No keys will be rendered if users haven't made any service tokens explicitly:
![image](https://user-images.githubusercontent.com/2850013/211668699-3ea25fb8-244a-42bf-9570-a67c3ce8be33.png)

Expected user pattern is to label your service tokens clearly here and they will be the only tokens present:
![image](https://user-images.githubusercontent.com/2850013/211668821-0d3c2ac9-5e5a-452e-b2dd-3b193cd1b1dc.png)

I can no longer authenticate into estuary-www with that service token, so there's no risk of mixing up that token with my session. This removes the risk of signing out with a service token in your cookie and accidentally revoking it, which would break your service's integration with estuary.
