### PR TITLE
Added Plausible Analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,15 @@
 .next
+.env
+.env.local
+.env-custom-development
+.env-development
+.env-textile
+.env-production
 package-lock.json
 node_modules
 .DS_STORE
 DS_STORE
+
 
 /**/*/package-lock.json
 /**/*/.DS_STORE

--- a/components/Page.tsx
+++ b/components/Page.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import Head from 'next/head';
+import PlausibleAnalyticsScript from './PlausibleAnalyticsScript';
 export default class IndexPage extends React.Component<any> {
   render() {
     const title = this.props.title;
@@ -30,6 +31,8 @@ export default class IndexPage extends React.Component<any> {
           <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png" />
 
           <link rel="shortcut icon" href="/static/favicon.ico" />
+          <script defer data-domain="estuary.tech" src="https://plausible.io/js/script.js"></script>
+          <PlausibleAnalyticsScript />
         </Head>
         {this.props.children}
       </React.Fragment>

--- a/components/Page.tsx
+++ b/components/Page.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-
 import Head from 'next/head';
 import PlausibleAnalyticsScript from './PlausibleAnalyticsScript';
+
 export default class IndexPage extends React.Component<any> {
   render() {
     const title = this.props.title;
@@ -31,7 +31,6 @@ export default class IndexPage extends React.Component<any> {
           <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png" />
 
           <link rel="shortcut icon" href="/static/favicon.ico" />
-          <script defer data-domain="estuary.tech" src="https://plausible.io/js/script.js"></script>
           <PlausibleAnalyticsScript />
         </Head>
         {this.props.children}

--- a/components/PlausibleAnalyticsScript.tsx
+++ b/components/PlausibleAnalyticsScript.tsx
@@ -1,0 +1,3 @@
+export default function PlausibleAnalyticsScript() {
+  return <script defer data-domain="estuary.tech" src="https://plausible.io/js/script.js"></script>;
+}


### PR DESCRIPTION
This pr adds [ Plausible analytics](https://plausible.io/) (which is a lighter version of google analytics with more data privacy) to the `head` component to track user traffic. Also adding `.env` to .gitignore 👀 

In Nextjs 13 there is a native `Script` tag which is also used on storage.market but it doesn't work in the version that we have here so I'm using a regular `script` HTML tag. Are we going to migrate estuary's codebase to Nextjs 13 once it gets more documentation/tutorials?


<img width="1418" alt="Screen Shot 2023-01-14 at 8 35 30 PM" src="https://user-images.githubusercontent.com/28320272/212506668-0423dc70-13d5-4825-8fec-e7b9438904de.png">

