### PR TITLE
Removed empty titles from the Navbar

### DIFF
--- a/components/ResponsiveNavbar.tsx
+++ b/components/ResponsiveNavbar.tsx
@@ -3,11 +3,7 @@ import styles from '@components/ResponsiveNavbar.module.scss';
 import { BreakpointEnum, useBreakpoint } from '@common/use-breakpoint';
 import * as React from 'react';
 
-const navItems = [
-  { name: 'Collaborators', href: '#collaborators' },
-  { name: 'Performance', href: '#performance' },
-  { name: 'Deals', href: '#deals' },
-];
+const navItems = [{ name: 'Collaborators', href: '#collaborators' }];
 
 function MobileNav({ navItems }) {
   const [isOpen, setIsOpen] = React.useState(false);


### PR DESCRIPTION
This pr removes the titles from the ecosystem page navbar since we removed the content for now