### PR TITLE
Fix feedback url in AuthenticatedSidebar

### DIFF
--- a/components/AuthenticatedSidebar.tsx
+++ b/components/AuthenticatedSidebar.tsx
@@ -48,7 +48,7 @@ function AuthenticatedLayout(props: any) {
       <a className={styles.item} href="/settings">
         Account
       </a>
-      <a className={styles.item} href="https://docs.estuary.tech/feedback" target="_blank">
+      <a className={styles.item} href="https://docs.estuary.tech/give-feedback" target="_blank">
         Feedback
       </a>
       <span


### PR DESCRIPTION
Fixes url route for Feedback in `AuthenticatedSidebar`.

after
![CleanShot 2023-03-04 at 12 55 38](https://user-images.githubusercontent.com/1177031/222932361-aff58a8f-d12e-4f69-b35f-604e8260cd3c.gif)

before
![CleanShot 2023-03-04 at 12 46 16](https://user-images.githubusercontent.com/1177031/222932406-c91145c5-91ee-4218-bbd7-9d7f6ff77088.gif)
