### PR TITLE
docs: add project status notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> [!WARNING]
+>  # Project Discontinued
+> 
+> The instance and its related API endpoints hosted at <https://estuary.tech> are discontinued and no longer maintained.
+> 
+> The codebase is provided as-is for anyone interested in forking or learning.
+
+---- 
+
 ![Post](https://next-s3-public.s3.us-west-2.amazonaws.com/social/estuary.hero.large.png)
 
 # Estuary WWW


### PR DESCRIPTION
We have people reaching out that https://estuary.tech/ does not work, surprised it is no more:

> [..]  https://docs.estuary.tech/ looks fine but   https://estuary.tech/ is down.
> [..]  the Github Repo isn’t archived either and I couldn’t find any notice regarding the deprecation: https://github.com/application-research/estuary

I'm submitting PRs to add notice to README and reduce confusion in the ecosystem.

cc @frrist